### PR TITLE
disable dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
-version: 2
-updates:
-  - package-ecosystem: gomod
-    directory: /
-    schedule:
-      interval: daily
+# version: 2
+# updates:
+#   - package-ecosystem: gomod
+#     directory: /
+#     schedule:
+#       interval: daily


### PR DESCRIPTION
Not necessary, just enabling security updates for now.