### PR TITLE
Fix and extend map server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 # FPKI
 
-TODO: This information is old and outdated.
+## Setting up local mapserver for testing
+
+- generate test policies:
+  `cd path/to/policy-generator; go run .`
+- clean DB:
+  `./tools/create_schema.sh`
+- ingest certificates (all `.csv` and `.gz` files located within a `bundled` subfolder are ingested):
+  `go run ./cmd/ingest path/to/cert-directory`
+- ingest root policy
+  `go run cmd/mapserver/main.go -policyFile path/to/policy-generator/output/pca.pc config.json`
+- ingest policies one by one
+  `for x in path/to/policy-generator/output/pc_*.pc; do go run cmd/mapserver/main.go -policyFile $x config.json; done`
+- run map server
+  `go run cmd/mapserver/main.go config.json`
+
+TODO: The information below is old and outdated.
 
 ## Features
 

--- a/cmd/ingest/certProcessor.go
+++ b/cmd/ingest/certProcessor.go
@@ -202,7 +202,7 @@ func (p *CertificateProcessor) ConsolidateDB() {
 		if _, err := p.conn.DB().Exec(str); err != nil {
 			panic(fmt.Errorf("reenabling keys: %s", err))
 		}
-		str = "ALTER TABLE certs_aux_tmp ADD PRIMARY KEY (id)"
+		str = "ALTER TABLE certs_aux_tmp ADD PRIMARY KEY (cert_id)"
 		if _, err := p.conn.DB().Exec(str); err != nil {
 			panic(fmt.Errorf("reenabling keys: %s", err))
 		}

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -106,7 +106,6 @@ func mainFunction() int {
 	config := db.NewConfig(
 		mysql.WithDefaults(),
 		mysql.WithEnvironment(),
-		mysql.WithLocalSocket("/var/run/mysqld/mysqld.sock"),
 	)
 	conn, err := mysql.Connect(config)
 	exitIfError(err)

--- a/cmd/mapserver/main.go
+++ b/cmd/mapserver/main.go
@@ -189,7 +189,7 @@ func runWithConfig(
 		})
 
 	// Listen in responder.
-	err = server.Listen(ctx)
+	err = server.ListenWithoutTLS(ctx)
 
 	// Regardless of the error, clean everything up.
 	cleanUp()

--- a/pkg/common/crypto/crypto.go
+++ b/pkg/common/crypto/crypto.go
@@ -8,10 +8,40 @@ import (
 	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
+	"regexp"
+	"strings"
+	"time"
 
 	"github.com/netsec-ethz/fpki/pkg/common"
 	"github.com/netsec-ethz/fpki/pkg/util"
 )
+
+func SignPolicyCertificateTimestamp(
+	pc *common.PolicyCertificate,
+	version int,
+	logId []byte,
+	key *rsa.PrivateKey,
+) (*common.SignedPolicyCertificateTimestamp, error) {
+	serializedPc, err := common.ToJSON(pc)
+	if err != nil {
+		return nil, fmt.Errorf("SignSPT | SerializePC | %w", err)
+	}
+
+	spt := common.NewSignedPolicyCertificateTimestamp(version, logId, time.Now(), nil)
+	signatureInput := common.NewSignedEntryTimestampSignatureInput(serializedPc, spt)
+	serializedSpt, err := common.ToJSON(signatureInput)
+	if err != nil {
+		return nil, fmt.Errorf("SignSPT | SerializeSPTInput | %w", err)
+	}
+
+	signature, err := SignBytes(serializedSpt, key)
+	if err != nil {
+		return nil, fmt.Errorf("SignSPT | Sign | %w", err)
+	}
+
+	spt.Signature = signature
+	return spt, nil
+}
 
 func SignBytes(b []byte, key *rsa.PrivateKey) ([]byte, error) {
 	hashOutput := sha256.Sum256(b)
@@ -177,6 +207,43 @@ func SignPolicyCertificateAsIssuer(
 
 	// No errors: modify the child policy certificate in-place.
 	childPolCert.IssuerSignature = signature
+
+	return nil
+}
+
+// verifies various constraints given by the issuer policy certificate and returns the first violated constraint, or nil if no constraints were violated
+func VerifyIssuerConstraints(
+	issuerPolCert *common.PolicyCertificate,
+	childPolCert *common.PolicyCertificate,
+) error {
+	// check validity period
+	if childPolCert.NotBefore.Before(issuerPolCert.NotBefore) {
+		return fmt.Errorf("policy certificate is valid before its issuer certificate (%v < %v)", childPolCert.NotBefore, issuerPolCert.NotBefore)
+	}
+	if issuerPolCert.NotAfter.Before(childPolCert.NotAfter) {
+		return fmt.Errorf("policy certificate is valid after its issuer certificate (%v > %v)", childPolCert.NotAfter, issuerPolCert.NotAfter)
+	}
+
+	// check domain constraint
+	// TODO (cyrill): could also check with public suffix list
+	validDomainName := regexp.MustCompile("([^.]+\\.)*([^.]+\\.?)?")
+	if !validDomainName.Match([]byte(childPolCert.DomainField)) {
+		return fmt.Errorf("Policy Certificate does not have a valid domain name: %s", childPolCert.DomainField)
+	}
+	if !validDomainName.Match([]byte(issuerPolCert.DomainField)) {
+		return fmt.Errorf("Issuer Policy Certificate does not have a valid domain name: %s", issuerPolCert.DomainField)
+	}
+	if issuerPolCert.DomainField != "" {
+		// all domain fields are accepted
+	} else if issuerPolCert.DomainField == childPolCert.DomainField {
+		// identical domain fields are accepted
+	} else {
+		if !strings.HasSuffix(childPolCert.DomainField, "."+issuerPolCert.DomainField) {
+			return fmt.Errorf("Policy certificate is not a subdomain of the issuer policy certificate")
+		} else {
+			// is valid subdomain
+		}
+	}
 
 	return nil
 }

--- a/pkg/common/embedded_policies.go
+++ b/pkg/common/embedded_policies.go
@@ -57,6 +57,35 @@ func (s SignedEntryTimestamp) Equal(x SignedEntryTimestamp) bool {
 		bytes.Equal(s.Signature, x.Signature)
 }
 
+type SignedEntryTimestampSignatureInput struct {
+	SignedEntryTimestamp
+	Entry []byte
+}
+
+func NewSignedEntryTimestampSignatureInput(
+	entry []byte,
+	spct *SignedPolicyCertificateTimestamp,
+) *SignedEntryTimestampSignatureInput {
+	return &SignedEntryTimestampSignatureInput{
+		SignedEntryTimestamp: SignedEntryTimestamp{
+			EmbeddedPolicyBase: EmbeddedPolicyBase{
+				PolicyPartBase: PolicyPartBase{
+					Version: spct.Version,
+				},
+			},
+			LogID:     spct.LogID,
+			AddedTS:   spct.AddedTS,
+			Signature: spct.Signature,
+		},
+		Entry: entry,
+	}
+}
+
+func (t SignedEntryTimestampSignatureInput) Equal(x SignedEntryTimestampSignatureInput) bool {
+	return t.SignedEntryTimestamp.Equal(x.SignedEntryTimestamp) &&
+		bytes.Equal(t.Entry, x.Entry)
+}
+
 func NewSignedPolicyCertificateTimestamp(
 	version int,
 	logID []byte,

--- a/pkg/common/json.go
+++ b/pkg/common/json.go
@@ -77,6 +77,8 @@ func (*serializableObjectBase) marshalJSON(obj any) (string, []byte, error) {
 		T = "trillian.Proof"
 	case trilliantypes.LogRootV1:
 		T = "logrootv1"
+	case SignedEntryTimestampSignatureInput:
+		T = "spctsiginput"
 	default:
 		valOf := reflect.ValueOf(obj)
 		switch valOf.Kind() {
@@ -207,6 +209,8 @@ func (o *serializableObjectBase) unmarshalTypeObject(T string, data []byte) (boo
 		obj, err = inflateObj[trillian.Proof](data)
 	case "logrootv1":
 		obj, err = inflateObj[trilliantypes.LogRootV1](data)
+	case "spctsiginput":
+		obj, err = inflateObj[SignedEntryTimestampSignatureInput](data)
 	default:
 		err = fmt.Errorf("unknown type represented by \"%s\"", T)
 		obj = nil

--- a/pkg/common/policy_common.go
+++ b/pkg/common/policy_common.go
@@ -11,6 +11,8 @@ type MarshallableDocumentBase struct {
 	JSONField []byte `json:"-"` // omit from JSON (un)marshaling
 }
 
+// TODO (cyrill): problem is that JSONField is not properly kept up to date (or may not even be set)
+// we could either replace it with ToJSON(o) or ensure that it is synchronized
 func (o MarshallableDocumentBase) Raw() []byte { return o.JSONField }
 
 // PolicyPart is an interface that is implemented by all objects that are part of the set

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -99,11 +99,17 @@ type policies interface {
 	RetrievePolicyPayloads(ctx context.Context, IDs []*common.SHA256Output) ([][]byte, error)
 }
 
+type certsAndPolicies interface {
+	// RetrieveCertificateOrPolicyPayloads returns the payloads for each identifier regardless whether it is a certificate or a policy
+	RetrieveCertificateOrPolicyPayloads(ctx context.Context, IDs []*common.SHA256Output) ([][]byte, error)
+}
+
 type Conn interface {
 	smt
 	dirty
 	certs
 	policies
+	certsAndPolicies
 
 	// TODO(juagargi) remove the temporary access to the sql.DB object
 	DB() *sql.DB

--- a/pkg/db/mysql/common.go
+++ b/pkg/db/mysql/common.go
@@ -1,0 +1,44 @@
+package mysql
+
+import (
+	"context"
+
+	"github.com/netsec-ethz/fpki/pkg/common"
+)
+
+// RetrievePolicyPayloads returns the payload for each certificate OR policy identified by the IDs
+// parameter, in the same order (element i corresponds to IDs[i]).
+func (c *mysqlDB) RetrieveCertificateOrPolicyPayloads(ctx context.Context, IDs []*common.SHA256Output,
+) ([][]byte, error) {
+	str := "SELECT policy_id,payload from policies WHERE policy_id IN " +
+		repeatStmt(1, len(IDs)) +
+		"UNION SELECT cert_id,payload from certs WHERE cert_id IN " +
+		repeatStmt(1, len(IDs))
+	params := make([]any, 2*len(IDs))
+	for i, id := range IDs {
+		params[i] = id[:]
+		params[len(IDs)+i] = id[:]
+	}
+	rows, err := c.db.QueryContext(ctx, str, params...)
+	if err != nil {
+		return nil, err
+	}
+
+	m := make(map[common.SHA256Output][]byte, len(IDs))
+	for rows.Next() {
+		var id, payload []byte
+		if err := rows.Scan(&id, &payload); err != nil {
+			return nil, err
+		}
+		idArray := (*common.SHA256Output)(id)
+		m[*idArray] = payload
+	}
+
+	// Sort them in the same order as the IDs.
+	payloads := make([][]byte, len(IDs))
+	for i, id := range IDs {
+		payloads[i] = m[*id]
+	}
+
+	return payloads, nil
+}

--- a/pkg/db/mysql/mysql_test.go
+++ b/pkg/db/mysql/mysql_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestCheckCertsExist(t *testing.T) {
-	ctx, cancelF := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()
 
 	// Configure a test DB.
@@ -71,7 +71,7 @@ func TestCoalesceForDirtyDomains(t *testing.T) {
 	// Because we are using "random" bytes deterministically here, set a fixed seed.
 	rand.Seed(1)
 
-	ctx, cancelF := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()
 
 	// Configure a test DB.
@@ -140,7 +140,7 @@ func TestCoalesceForDirtyDomains(t *testing.T) {
 }
 
 func TestRetrieveCertificatePayloads(t *testing.T) {
-	ctx, cancelF := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()
 
 	// Configure a test DB.
@@ -197,7 +197,7 @@ func TestRetrieveCertificatePayloads(t *testing.T) {
 }
 
 func TestLastCTlogServerState(t *testing.T) {
-	ctx, cancelF := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()
 
 	// Configure a test DB.

--- a/pkg/db/mysql/policies.go
+++ b/pkg/db/mysql/policies.go
@@ -91,14 +91,14 @@ func (c *mysqlDB) UpdatePolicies(ctx context.Context, ids, parents []*common.SHA
 	return nil
 }
 
-// UpdateDomainPolicies updates the domain_certs table.
+// UpdateDomainPolicies updates the domain_policies table.
 func (c *mysqlDB) UpdateDomainPolicies(ctx context.Context,
 	domainIDs, policyIDs []*common.SHA256Output) error {
 
 	if len(domainIDs) == 0 {
 		return nil
 	}
-	// Insert into domain_certs:
+	// Insert into domain_policies:
 	str := "INSERT IGNORE INTO domain_policies (domain_id,policy_id) VALUES " +
 		repeatStmt(len(policyIDs), 2)
 	data := make([]interface{}, 2*len(policyIDs))

--- a/pkg/mapserver/logfetcher/logfetcher_test.go
+++ b/pkg/mapserver/logfetcher/logfetcher_test.go
@@ -261,7 +261,7 @@ func TestLogFetcher(t *testing.T) {
 }
 
 func TestTimeoutLogFetcher(t *testing.T) {
-	ctx, cancelF := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()
 	f, err := NewLogFetcher(testURL)
 	require.NoError(t, err)

--- a/pkg/mapserver/mapserver.go
+++ b/pkg/mapserver/mapserver.go
@@ -153,6 +153,7 @@ func (s *MapServer) Listen(ctx context.Context) error {
 			server.Shutdown(ctx)
 		}()
 		// This call blocks
+		fmt.Printf("Listening on %d\n", APIPort)
 		chanErr <- server.ListenAndServeTLS("", "")
 
 	}()

--- a/pkg/mapserver/responder/responder_test.go
+++ b/pkg/mapserver/responder/responder_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestNewResponder(t *testing.T) {
-	ctx, cancelF := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()
 
 	// Configure a test DB.
@@ -64,7 +64,7 @@ func TestProof(t *testing.T) {
 	// Because we are using "random" bytes deterministically here, set a fixed seed.
 	rand.Seed(1)
 
-	ctx, cancelF := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()
 
 	// Configure a test DB.

--- a/pkg/mapserver/trie/trie_test.go
+++ b/pkg/mapserver/trie/trie_test.go
@@ -209,7 +209,7 @@ func TestTrieUpdateAndDelete(t *testing.T) {
 // TestTrieMerkleProof: test if merkle proof is correct
 func TestTrieMerkleProof(t *testing.T) {
 	rand.Seed(1)
-	ctx, cancelF := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()
 
 	config, removeF := testdb.ConfigureTestDB(t)

--- a/pkg/mapserver/updater/updater.go
+++ b/pkg/mapserver/updater/updater.go
@@ -289,8 +289,12 @@ func UpdateWithOverwrite(ctx context.Context, conn db.Conn, domainNames [][]stri
 	policyIDs := make([]*common.SHA256Output, len(policies))
 	policySubjects := make([]string, len(policies))
 	for i, pol := range policies {
-		payloads[i] = pol.Raw()
-		id := common.SHA256Hash32Bytes(pol.Raw())
+		payload, err := common.ToJSON(pol)
+		if err != nil {
+			return err
+		}
+		payloads[i] = payload
+		id := common.SHA256Hash32Bytes(payload)
 		policyIDs[i] = &id
 		policySubjects[i] = pol.Domain()
 	}
@@ -336,8 +340,12 @@ func UpdateWithKeepExisting(ctx context.Context, conn db.Conn, domainNames [][]s
 	policyIDs := make([]*common.SHA256Output, len(policies))
 	policySubjects := make([]string, len(policies))
 	for i, pol := range policies {
-		payloads[i] = pol.Raw()
-		id := common.SHA256Hash32Bytes(pol.Raw())
+		payload, err := common.ToJSON(pol)
+		if err != nil {
+			return err
+		}
+		payloads[i] = payload
+		id := common.SHA256Hash32Bytes(payload)
 		policyIDs[i] = &id
 		policySubjects[i] = pol.Domain()
 	}

--- a/pkg/pca/pca.go
+++ b/pkg/pca/pca.go
@@ -184,6 +184,7 @@ func (pca *PCA) SignAndLogRequest(
 // canSkipCoolOffPeriod verifies that the owner's signature is correct, if there is an owner's
 // signature in the request, and this PCA has the policy certificate used to signed said request.
 // It returns true if this PCA can skip the cool off period, false otherwise.
+// TODO (cyrill): I think the cool off period should be enforced on the client and not the PCA. Unless the PCA performs additional verification if no signature from a valid policy certificate exists
 func (pca *PCA) canSkipCoolOffPeriod(req *common.PolicyCertificateSigningRequest) (bool, error) {
 	// Owner's signature?
 	if len(req.OwnerSignature) == 0 {

--- a/pkg/tests/testdb/testdb.go
+++ b/pkg/tests/testdb/testdb.go
@@ -26,7 +26,7 @@ func Connect(t tests.T, config *db.Configuration) db.Conn {
 // returns the configuration and the DB removal function that should be called with defer.
 func ConfigureTestDB(t tests.T) (*db.Configuration, func()) {
 	dbName := t.Name()
-	config := db.NewConfig(mysql.WithDefaults(), db.WithDB(dbName))
+	config := db.NewConfig(mysql.WithDefaults(), mysql.WithEnvironment(), db.WithDB(dbName))
 
 	// New context to create the DB.
 	ctx, cancelF := context.WithTimeout(context.Background(), 2*time.Second)

--- a/tests/integration/mapserver/main.go
+++ b/tests/integration/mapserver/main.go
@@ -123,7 +123,6 @@ func checkResponse(
 		domainName,
 	))
 	require.NoError(t, err)
-	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	dec := json.NewDecoder(resp.Body)
 	var proofChain []*mapcommon.MapServerResponse

--- a/tools/create_schema.sh
+++ b/tools/create_schema.sh
@@ -6,7 +6,14 @@ create_new_db() {
 set -e
 
 DBNAME=$1
-MYSQLCMD="mysql -u root"
+
+MYSQLCMD="mysql -u ${MYSQL_USER:-root}"
+if [ -n "${MYSQL_PASSWORD}" ]; then
+    MYSQLCMD="${MYSQLCMD} -p${MYSQL_PASSWORD}"
+fi
+if [ -n "${MYSQL_HOST}" ] || [ -n "${MYSQL_PORT}" ]; then
+    MYSQLCMD="${MYSQLCMD} -h ${MYSQL_HOST:-localhost} -P ${MYSQL_PORT:-3306} --protocol TCP"
+fi
 
 
 CMD=$(cat <<EOF
@@ -124,9 +131,10 @@ EOF
 CMD=$(cat <<EOF
 USE $DBNAME;
 CREATE TABLE root (
-  key32 VARBINARY(32) NOT NULL,
+    key32 VARBINARY(32) NOT NULL,
 
-  PRIMARY KEY (key32)
+    -- constraints to ensure that only a single root value exists at any time by having a single possible value for the primary key
+    single_row_pk char(25) NOT NULL PRIMARY KEY DEFAULT 'PK_RestrictToOneRootValue' CHECK (single_row_pk='PK_RestrictToOneRootValue')
 ) ENGINE=MyISAM CHARSET=binary COLLATE=binary;
 EOF
   )


### PR DESCRIPTION
Various Improvements and fixes for the map server:
- fix MHT root value bug (only allow single root value at each point in time)
- fix SPCT signature calculation (now includes timestamp in signature calculation)
- allow fetching certificates and policies with a single API call
- add option to insert single policy from file
- add helper option to verify policy chain constraints (used by browser extension's web assembly part)
- add documentation