### PR TITLE
Cyrill Map Server Fixes and Improvements

### DIFF
--- a/cmd/mapserver/main.go
+++ b/cmd/mapserver/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/rsa"
 	"flag"
 	"fmt"
 	"os"
@@ -170,7 +171,11 @@ func runWithConfig(
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Running map server with root: %v\n", root)
+	base64PublicKey, err := util.RSAPublicToDERBase64(server.Cert.PublicKey.(*rsa.PublicKey))
+	if err != nil {
+		return fmt.Errorf("error converting public key to DER base64: %w", err)
+	}
+	fmt.Printf("Running map server with root: %x and public key: %s\n", *root, base64PublicKey)
 
 	// Should update now?
 	if updateNow {

--- a/cmd/mapserver/main.go
+++ b/cmd/mapserver/main.go
@@ -132,6 +132,7 @@ func writeSampleConfig() error {
 		CTLogServerURLs:    []string{"https://ct.googleapis.com/logs/xenon2023/"},
 		CertificatePemFile: "tests/testdata/servercert.pem",
 		PrivateKeyPemFile:  "tests/testdata/serverkey.pem",
+		HttpAPIPort:        8443,
 
 		UpdateAt: util.NewTimeOfDay(3, 00, 00, 00),
 		UpdateTimer: util.DurationWrap{

--- a/cmd/mapserver/main.go
+++ b/cmd/mapserver/main.go
@@ -175,7 +175,11 @@ func runWithConfig(
 	if err != nil {
 		return fmt.Errorf("error converting public key to DER base64: %w", err)
 	}
-	fmt.Printf("Running map server with root: %x and public key: %s\n", *root, base64PublicKey)
+	if root == nil {
+		fmt.Printf("Running empy map server with public key: %s\n", base64PublicKey)
+	} else {
+		fmt.Printf("Running map server with root: %x and public key: %s\n", *root, base64PublicKey)
+	}
 
 	// Should update now?
 	if updateNow {

--- a/cmd/mapserver/main.go
+++ b/cmd/mapserver/main.go
@@ -110,7 +110,9 @@ func insertPolicyFromFile(policyFile string) error {
 	if err != nil {
 		return err
 	}
-	if bytes.Equal(root[:], newRoot[:]) {
+	if root == nil {
+		fmt.Printf("MHT root value initially set to %v\n", newRoot)
+	} else if bytes.Equal(root[:], newRoot[:]) {
 		fmt.Printf("MHT root value was not updated (%v)\n", newRoot)
 	} else {
 		fmt.Printf("MHT root value updated from %v to %v\n", root, newRoot)

--- a/cmd/mapserver/main.go
+++ b/cmd/mapserver/main.go
@@ -205,9 +205,12 @@ func runWithConfig(
 	// Set update cycle timer.
 	util.RunWhen(ctx, conf.UpdateAt.NextTimeOfDay(), conf.UpdateTimer.Duration,
 		func(ctx context.Context) {
-			err := server.PruneAndUpdate(ctx)
+			updatePossible, err := server.PruneAndUpdateIfPossible(ctx)
 			if err != nil {
 				fmt.Printf("ERROR: update returned %s\n", err)
+			}
+			if !updatePossible {
+				fmt.Printf("WARNING: Unable to schedule update due to currently running update (CT log fetching and map server ingestion speed may be too low) at %s\n", time.Now().UTC().Format(time.RFC3339))
 			}
 		})
 

--- a/cmd/mapserver/main.go
+++ b/cmd/mapserver/main.go
@@ -19,6 +19,8 @@ import (
 	"github.com/netsec-ethz/fpki/pkg/util"
 )
 
+const VERSION = "0.1.0"
+
 const waitForExitBeforePanicTime = 10 * time.Second
 
 func main() {
@@ -37,11 +39,19 @@ func mainFunc() int {
 	}
 	flag.CommandLine.Usage = flag.Usage
 
+	var showVersion bool
+	flag.BoolVar(&showVersion, "version", false, "Print map server version")
+	flag.BoolVar(&showVersion, "v", false, "Print map server version")
 	updateVar := flag.Bool("updateNow", false, "Immediately trigger an update cycle")
 	createSampleConfig := flag.Bool("createSampleConfig", false,
 		"Create configuration file specified by positional argument")
 	insertPolicyVar := flag.String("policyFile", "", "policy certificate file to be ingested into the mapserver")
 	flag.Parse()
+
+	if showVersion {
+		fmt.Printf("FP-PKI Map Server %s\n", VERSION)
+		return 0
+	}
 
 	// We need the configuration file as the first positional argument.
 	if flag.NArg() != 1 {
@@ -179,9 +189,9 @@ func runWithConfig(
 		return fmt.Errorf("error converting public key to DER base64: %w", err)
 	}
 	if root == nil {
-		fmt.Printf("Running empy map server with public key: %s\n", base64PublicKey)
+		fmt.Printf("Running empy map server (%s) with public key: %s\n", VERSION, base64PublicKey)
 	} else {
-		fmt.Printf("Running map server with root: %x and public key: %s\n", *root, base64PublicKey)
+		fmt.Printf("Running map server (%s) with root: %x and public key: %s\n", VERSION, *root, base64PublicKey)
 	}
 
 	// Should update now?

--- a/pkg/common/crypto/crypto.go
+++ b/pkg/common/crypto/crypto.go
@@ -53,6 +53,15 @@ func SignBytes(b []byte, key *rsa.PrivateKey) ([]byte, error) {
 	return signature, nil
 }
 
+func VerifySignedBytes(b []byte, signature []byte, key *rsa.PublicKey) error {
+	hashOutput := sha256.Sum256(b)
+	err := rsa.VerifyPKCS1v15(key, crypto.SHA256, hashOutput[:], signature)
+	if err != nil {
+		return fmt.Errorf("VerifySignature | VerifyPKCS1V15 | %w", err)
+	}
+	return nil
+}
+
 // SignAsOwner generates a signature using the owner's key, and fills the owner signature in
 // the policy certificate signing request.
 //

--- a/pkg/common/policies.go
+++ b/pkg/common/policies.go
@@ -90,10 +90,16 @@ func (o PolicyCertificate) Raw() ([]byte, error) {
 
 // PolicyAttributes is a domain policy that specifies what is or not acceptable for a domain.
 type PolicyAttributes struct {
-	// List of CA subject names allowed to issue certificates for this domain and subdomains. The string representation is according to the golang x509 library golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
+	// List of CA subject names allowed to issue certificates for this domain and subdomains. The
+	// string representation is according to the golang x509 library
+	// golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
 	AllowedCAs []string `json:",omitempty"`
 
-	// The following three attributes specify which subdomains are allowed and which are excluded (i.e., policies do not apply to these subdomains). Only one of these attributes is allowed to be set to the wildcard value "*" and covers all domains that are not covered by other attributes. No subdomain name can be covered by more than one attribute (including the wildcard value). Only single labels without "." can be specified.
+	// The following three attributes specify which subdomains are allowed and which are excluded
+	// (i.e., policies do not apply to these subdomains). Only one of these attributes is allowed to
+	// be set to the wildcard value "*" and covers all domains that are not covered by other
+	// attributes. No subdomain name can be covered by more than one attribute (including the
+	// wildcard value). Only single labels without "." can be specified.
 
 	// This attribute lists subdomains that are allowed
 	AllowedSubdomains []string `json:",omitempty"`
@@ -162,12 +168,17 @@ func (a PolicyAttributes) ValidateAttributes() error {
 }
 
 func (a PolicyAttributes) CheckDomainValidity(policyAttributeDomain, domain string) PolicyAttributeDomainValidityResult {
+	// remove trailing dot if present (example.com. -> example.com)
 	policyAttributeDomain, _ = strings.CutSuffix(policyAttributeDomain, ".")
 	domain, _ = strings.CutSuffix(domain, ".")
+
+	// get relative domain path compared to the policy attribute's domain (www.test.example.com -> www.test
 	targetSubdomain, ok := strings.CutSuffix(domain, "."+policyAttributeDomain)
 	if !ok {
 		return PolicyAttributeDomainNotApplicable
 	}
+
+	// get the relevant subdomain label on which the domain validity is evaluated on (www.test.example.com -> test)
 	targetSubdomainLabels := strings.Split(targetSubdomain, ".")
 	targetSubdomainLabel := targetSubdomainLabels[len(targetSubdomainLabels)-1]
 

--- a/pkg/db/mysql/init.go
+++ b/pkg/db/mysql/init.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/url"
+	"time"
 
 	_ "github.com/go-sql-driver/mysql"
 
@@ -32,6 +33,11 @@ func Connect(config *db.Configuration) (db.Conn, error) {
 	// DB connections complete their work.
 	maxConnections := 8
 	db.SetMaxOpenConns(maxConnections)
+
+	// Set the maximum idle connection time to a lower value than the mysql wait_timeout (8h) to
+	// ensure that idle connections that are closed by the mysql DB are not reused
+	connMaxIdleTime := 1 * time.Hour
+	db.SetConnMaxIdleTime(connMaxIdleTime)
 
 	// check schema
 	if config.CheckSchema {

--- a/pkg/mapserver/config/config.go
+++ b/pkg/mapserver/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	DBConfig           *db.Configuration
 	CertificatePemFile string // A X509 pem certificate
 	PrivateKeyPemFile  string // A RSA pem key
+	HttpAPIPort        int
 
 	UpdateAt    util.TimeOfDayWrap
 	UpdateTimer util.DurationWrap

--- a/pkg/mapserver/logfetcher/logfetcher.go
+++ b/pkg/mapserver/logfetcher/logfetcher.go
@@ -99,7 +99,7 @@ func NewLogFetcher(url string) (*LogFetcher, error) {
 		serverBatchSize:  defaultServerBatchSize,
 		processBatchSize: defaultProcessBatchSize,
 		ctClient:         ctClient,
-		chanResults:      make(chan *result, preloadCount),
+		chanResults:      nil,
 	}, nil
 }
 
@@ -123,6 +123,7 @@ func (f LogFetcher) GetCurrentState(ctx context.Context) (State, error) {
 // StartFetching will start fetching certificates in the background, so that there is
 // at most two batches ready to be immediately read by NextBatch.
 func (f *LogFetcher) StartFetching(start, end int64) {
+	f.chanResults = make(chan *result, preloadCount)
 	f.start = start
 	f.end = end
 	go f.fetch()

--- a/pkg/mapserver/logfetcher/logfetcher.go
+++ b/pkg/mapserver/logfetcher/logfetcher.go
@@ -233,7 +233,7 @@ func (f *LogFetcher) fetch() {
 			}
 			// Certificate.
 			cert, err := ctx509.ParseCertificate(raw.Cert.Data)
-			if err != nil {
+			if ctx509.IsFatal(err) {
 				f.chanResults <- &result{
 					err: err,
 				}

--- a/pkg/mapserver/logfetcher/logfetcher.go
+++ b/pkg/mapserver/logfetcher/logfetcher.go
@@ -234,6 +234,8 @@ func (f *LogFetcher) fetch() {
 			}
 			// Certificate.
 			cert, err := ctx509.ParseCertificate(raw.Cert.Data)
+			// Accept the same certificates as CT logs, i.e., don't be too restrictive in terms of
+			// which certificates to reject (i.e., allow for non-fatal parsing/validation errors)
 			if ctx509.IsFatal(err) {
 				f.chanResults <- &result{
 					err: err,

--- a/pkg/mapserver/mapserver.go
+++ b/pkg/mapserver/mapserver.go
@@ -124,7 +124,9 @@ func NewMapServer(ctx context.Context, conf *config.Config) (*MapServer, error) 
 		for {
 			select {
 			case c := <-s.updateChan:
+				// TODO: ensure that the Mapserver is never in an inconsistent state. Currently, if the new SMT is applied but the responder does not yet use the updated SMT root value, queries will fail
 				s.pruneAndUpdate(c)
+				resp.ReloadRoot(ctx)
 			case <-ctx.Done():
 				// Requested to exit.
 				close(s.updateChan)

--- a/pkg/mapserver/mapserver.go
+++ b/pkg/mapserver/mapserver.go
@@ -126,7 +126,10 @@ func NewMapServer(ctx context.Context, conf *config.Config) (*MapServer, error) 
 			case c := <-s.updateChan:
 				// TODO: ensure that the Mapserver is never in an inconsistent state. Currently, if the new SMT is applied but the responder does not yet use the updated SMT root value, queries will fail
 				s.pruneAndUpdate(c)
-				resp.ReloadRoot(ctx)
+				err := s.Responder.ReloadRootAndSignTreeHead(c, s.Key)
+				if err != nil {
+					s.updateErrChan <- err
+				}
 			case <-ctx.Done():
 				// Requested to exit.
 				close(s.updateChan)

--- a/pkg/mapserver/mapserver.go
+++ b/pkg/mapserver/mapserver.go
@@ -345,6 +345,7 @@ func (s *MapServer) updateCerts(ctx context.Context) error {
 	defer s.Updater.StopFetching()
 
 	// Main update loop.
+	start := time.Now()
 	for s.Updater.NextBatch(ctx) {
 		// print progress information
 		logUrl, currentIndex, maxIndex, err := s.Updater.GetProgress()
@@ -353,9 +354,11 @@ func (s *MapServer) updateCerts(ctx context.Context) error {
 		}
 		fmt.Printf("Running updater for log %s in range (%d, %d)\n", logUrl, currentIndex, maxIndex)
 
-		n, err := s.Updater.UpdateNextBatch(ctx)
+		fetchDuration := time.Now().Sub(start)
+		start = time.Now()
 
-		fmt.Printf("updated %5d certs batch at %s\n", n, getTime())
+		n, err := s.Updater.UpdateNextBatch(ctx)
+		fmt.Printf("Fetched %d certs in %.2f seconds at %s\n", n, fetchDuration.Seconds(), getTime())
 		if err != nil {
 			// We stop the loop here, as probably requires manual inspection of the logs, etc.
 			return fmt.Errorf("updating next batch of x509 certificates: %w", err)

--- a/pkg/mapserver/mapserver.go
+++ b/pkg/mapserver/mapserver.go
@@ -203,6 +203,19 @@ func (s *MapServer) Shutdown(ctx context.Context) {
 }
 
 // PruneAndUpdate triggers an update. If an ongoing update is still in process, it blocks.
+func (s *MapServer) PruneAndUpdateIfPossible(ctx context.Context) (bool, error) {
+	select {
+	// Signal we want an update.
+	case s.updateChan <- ctx:
+		// Wait for the answer (in form of an error).
+		err := <-s.updateErrChan
+		return true, err
+	default:
+		return false, nil
+	}
+}
+
+// PruneAndUpdate triggers an update. If an ongoing update is still in process, it blocks.
 func (s *MapServer) PruneAndUpdate(ctx context.Context) error {
 	// Signal we want an update.
 	s.updateChan <- ctx

--- a/pkg/mapserver/mapserver.go
+++ b/pkg/mapserver/mapserver.go
@@ -341,6 +341,13 @@ func (s *MapServer) updateCerts(ctx context.Context) error {
 
 	// Main update loop.
 	for s.Updater.NextBatch(ctx) {
+		// print progress information
+		logUrl, currentIndex, maxIndex, err := s.Updater.GetProgress()
+		if err != nil {
+			return fmt.Errorf("retrieve progress: %s", err)
+		}
+		fmt.Printf("Running updater for log %s in range (%d, %d)\n", logUrl, currentIndex, maxIndex)
+
 		n, err := s.Updater.UpdateNextBatch(ctx)
 
 		fmt.Printf("updated %5d certs batch at %s\n", n, getTime())

--- a/pkg/mapserver/mapserver.go
+++ b/pkg/mapserver/mapserver.go
@@ -202,7 +202,9 @@ func (s *MapServer) Shutdown(ctx context.Context) {
 	s.apiStopServerChan <- struct{}{}
 }
 
-// PruneAndUpdate triggers an update. If an ongoing update is still in process, it blocks.
+// PruneAndUpdateIfPossible tries to trigger an update if no update is currently running.
+// If an ongoing update is still in process, it returns false. Returns true if a new update was
+// triggered.
 func (s *MapServer) PruneAndUpdateIfPossible(ctx context.Context) (bool, error) {
 	select {
 	// Signal we want an update.

--- a/pkg/mapserver/mapserver.go
+++ b/pkg/mapserver/mapserver.go
@@ -124,7 +124,9 @@ func NewMapServer(ctx context.Context, conf *config.Config) (*MapServer, error) 
 		for {
 			select {
 			case c := <-s.updateChan:
-				// TODO: ensure that the Mapserver is never in an inconsistent state. Currently, if the new SMT is applied but the responder does not yet use the updated SMT root value, queries will fail
+				// TODO: ensure that the Mapserver is never in an inconsistent state. Currently, if
+				// the new SMT is applied but the responder does not yet use the updated SMT root
+				// value, queries will fail
 				s.pruneAndUpdate(c)
 				err := s.Responder.ReloadRootAndSignTreeHead(c, s.Key)
 				if err != nil {

--- a/pkg/mapserver/mapserver_test.go
+++ b/pkg/mapserver/mapserver_test.go
@@ -54,6 +54,7 @@ func TestServer(t *testing.T) {
 		DBConfig:           dbConf,
 		CertificatePemFile: "../../tests/testdata/servercert.pem",
 		PrivateKeyPemFile:  "../../tests/testdata/serverkey.pem",
+		HttpAPIPort:        8443,
 	}
 
 	// Run mapserver:
@@ -97,7 +98,7 @@ func TestServer(t *testing.T) {
 			defer wgClients.Done()
 
 			resp, err := client.Get(fmt.Sprintf("https://localhost:%d/getproof?domain=%s",
-				mapserver.APIPort, domains[rand.Intn(len(domains))]))
+				server.HttpAPIPort, domains[rand.Intn(len(domains))]))
 			require.NoError(t, err)
 			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
@@ -186,7 +187,7 @@ func benchmarkAPIGetProof(b *testing.B, numDifferentDomains int) {
 			defer wg.Done()
 
 			resp, err := client.Get(fmt.Sprintf("https://localhost:%d/getproof?domain=%s",
-				mapserver.APIPort, domains[rand.Intn(len(domains))]))
+				server.HttpAPIPort, domains[rand.Intn(len(domains))]))
 			b.StopTimer()
 			require.NoError(b, err)
 			body, err := io.ReadAll(resp.Body)
@@ -267,7 +268,7 @@ func benchmarkAPIGetPayloads(b *testing.B, numDifferentDomains int) {
 
 			ID := hex.EncodeToString(certIDs[rand.Intn(len(certIDs))][:])
 			resp, err := client.Get(fmt.Sprintf("https://localhost:%d/getcertpayloads?ids=%s",
-				mapserver.APIPort, ID))
+				server.HttpAPIPort, ID))
 			b.StopTimer()
 			require.NoError(b, err)
 			body, err := io.ReadAll(resp.Body)

--- a/pkg/mapserver/responder/responder.go
+++ b/pkg/mapserver/responder/responder.go
@@ -29,15 +29,18 @@ func NewMapResponder(
 		conn: conn,
 		smt:  nil,
 	}
-	err := r.ReloadRoot(ctx)
+	err := r.ReloadRootAndSignTreeHead(ctx, privateKey)
 	if err != nil {
 		return nil, err
 	}
 
-	return r, r.signTreeHead(privateKey)
+	return r, nil
 }
 
-func (r *MapResponder) ReloadRoot(ctx context.Context) error {
+func (r *MapResponder) ReloadRootAndSignTreeHead(
+	ctx context.Context,
+	privateKey *rsa.PrivateKey,
+) error {
 	// Load root.
 	var root []byte
 	if rootID, err := r.conn.LoadRoot(ctx); err != nil {
@@ -54,7 +57,9 @@ func (r *MapResponder) ReloadRoot(ctx context.Context) error {
 
 	// Use the new SMT
 	r.smt = smt
-	return nil
+
+	// sign the SMT root
+	return r.signTreeHead(privateKey)
 }
 
 func (r *MapResponder) GetProof(ctx context.Context, domainName string,

--- a/pkg/mapserver/updater/updater.go
+++ b/pkg/mapserver/updater/updater.go
@@ -65,6 +65,10 @@ func NewMapUpdater(config *db.Configuration, urls []string) (*MapUpdater, error)
 	}, nil
 }
 
+func (u *MapUpdater) GetProgress() (string, int, int, error) {
+	return u.Fetchers[u.currFetcher].URL(), int(u.lastState.Size), int(u.currState.Size), nil
+}
+
 // StartFetchingRemaining retrieves the last stored index number for this CT log server, and the
 // current last index, and uses them to call StartFetching.
 // It returns an error if there was one retrieving the start or end indices.

--- a/pkg/pca/pca.go
+++ b/pkg/pca/pca.go
@@ -154,7 +154,10 @@ func (pca *PCA) SignAndLogRequest(
 	if err != nil {
 		return nil, err
 	}
-	if !skip {
+	// TODO (cyrill): I think the cool off period should be enforced on the client and not the
+	// PCA. Unless the PCA performs additional verification if no signature from a valid policy
+	// certificate exists. For now, always skip the cooloff period
+	if false && !skip {
 		return nil, fmt.Errorf("for now we don't support cool off periods; all requests must " +
 			"be signed by the owner")
 	}
@@ -184,7 +187,6 @@ func (pca *PCA) SignAndLogRequest(
 // canSkipCoolOffPeriod verifies that the owner's signature is correct, if there is an owner's
 // signature in the request, and this PCA has the policy certificate used to signed said request.
 // It returns true if this PCA can skip the cool off period, false otherwise.
-// TODO (cyrill): I think the cool off period should be enforced on the client and not the PCA. Unless the PCA performs additional verification if no signature from a valid policy certificate exists
 func (pca *PCA) canSkipCoolOffPeriod(req *common.PolicyCertificateSigningRequest) (bool, error) {
 	// Owner's signature?
 	if len(req.OwnerSignature) == 0 {

--- a/pkg/util/pem.go
+++ b/pkg/util/pem.go
@@ -2,10 +2,27 @@ package util
 
 import (
 	"crypto/rsa"
+	"encoding/base64"
 	"fmt"
 
 	ctx509 "github.com/google/certificate-transparency-go/x509"
 )
+
+func RSAPublicToDERBase64(pubKey *rsa.PublicKey) (string, error) {
+	derBytes, err := RSAPublicToDERBytes(pubKey)
+	if err != nil {
+		return "", fmt.Errorf("Failed to convert public key to DER format: %s", err)
+	}
+	return base64.StdEncoding.EncodeToString(derBytes), nil
+}
+
+func DERBase64ToRSAPublic(base64PubKey string) (*rsa.PublicKey, error) {
+	der, err := base64.StdEncoding.DecodeString(base64PubKey)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to decode base64 public key: %s", err)
+	}
+	return DERBytesToRSAPublic(der)
+}
 
 func RSAPublicToDERBytes(pubKey *rsa.PublicKey) ([]byte, error) {
 	return ctx509.MarshalPKIXPublicKey(pubKey)

--- a/tests/integration/mapserver/main.go
+++ b/tests/integration/mapserver/main.go
@@ -65,6 +65,7 @@ func mainFunc() int {
 		DBConfig:           dbConf,
 		CertificatePemFile: "./tests/testdata/servercert.pem",
 		PrivateKeyPemFile:  "./tests/testdata/serverkey.pem",
+		HttpAPIPort:        8443,
 	}
 
 	// Mapserver:
@@ -93,17 +94,17 @@ func mainFunc() int {
 		rawPolicies[i] = raw
 	}
 	// Check responses for a.com, b.com and c.com .
-	checkResponse(t, client, "a.com", []common.SHA256Output{
+	checkResponse(t, server.HttpAPIPort, client, "a.com", []common.SHA256Output{
 		common.SHA256Hash32Bytes(certs[0].Raw),
 		common.SHA256Hash32Bytes(certs[1].Raw),
 		common.SHA256Hash32Bytes(certs[2].Raw),
 		common.SHA256Hash32Bytes(certs[3].Raw),
 	})
-	checkResponse(t, client, "b.com", []common.SHA256Output{
+	checkResponse(t, server.HttpAPIPort, client, "b.com", []common.SHA256Output{
 		common.SHA256Hash32Bytes(rawPolicies[0]),
 		common.SHA256Hash32Bytes(rawPolicies[1]),
 	})
-	checkResponse(t, client, "c.com", []common.SHA256Output{
+	checkResponse(t, server.HttpAPIPort, client, "c.com", []common.SHA256Output{
 		common.SHA256Hash32Bytes(certs[4].Raw),
 		common.SHA256Hash32Bytes(certs[5].Raw),
 		common.SHA256Hash32Bytes(certs[6].Raw),
@@ -117,6 +118,7 @@ func mainFunc() int {
 
 func checkResponse(
 	t tests.T,
+	APIPort int,
 	client *http.Client,
 	domainName string,
 	ids []common.SHA256Output,
@@ -125,7 +127,7 @@ func checkResponse(
 	// Proof of inclusion.
 	t.Logf("verifying inclusion of %s", domainName)
 	resp, err := client.Get(fmt.Sprintf("https://localhost:%d/getproof?domain=%s",
-		mapserver.APIPort,
+		APIPort,
 		domainName,
 	))
 	require.NoError(t, err)
@@ -176,7 +178,7 @@ func checkResponse(
 			collatedIDs += hex.EncodeToString(id[:])
 		}
 		resp, err = client.Get(fmt.Sprintf("https://localhost:%d/%s?ids=%s",
-			mapserver.APIPort,
+			APIPort,
 			group.fcn,
 			collatedIDs,
 		))


### PR DESCRIPTION
This combines various bug fixes and improvements for the map server:

- Extend config with HTTP Port
- Extend logging output
- Sign STH after certificate update
- Fix periodic fetching from CT logs
- Extend policy attributes with: blocklisted subdomains and excluded subdomains (i.e., subdomains for which the policy attributes do not apply)
- Add various helper functions related to signing/verifying, cryptographic format changes, policy attribute verification

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/fpki/57)
<!-- Reviewable:end -->
