### PR TITLE
Use slices of values (not pointers) for IDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/transparency-dev/merkle v0.0.2
 	go.uber.org/atomic v1.11.0
+	go.uber.org/mock v0.4.0
 	golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8
 	golang.org/x/net v0.24.0
 	golang.org/x/sync v0.7.0
@@ -58,7 +59,6 @@ require (
 	go.opentelemetry.io/otel v1.22.0 // indirect
 	go.opentelemetry.io/otel/metric v1.22.0 // indirect
 	go.opentelemetry.io/otel/trace v1.22.0 // indirect
-	go.uber.org/mock v0.4.0 // indirect
 	golang.org/x/crypto v0.22.0 // indirect
 	golang.org/x/oauth2 v0.17.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect

--- a/pkg/common/hasher.go
+++ b/pkg/common/hasher.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"hash"
+
 	sha256 "github.com/minio/sha256-simd"
 )
 
@@ -20,4 +22,28 @@ func SHA256Hash32Bytes(data ...[]byte) SHA256Output {
 	output := SHA256Hash(data...) // will never be empty, will always be 32 bytes.
 	ptr := (*SHA256Output)(output)
 	return *ptr
+}
+
+type Hasher struct {
+	hasher  hash.Hash
+	storage SHA256Output
+}
+
+func NewHasher() *Hasher {
+	return &Hasher{
+		hasher: sha256.New(),
+	}
+}
+
+func (h *Hasher) Hash(hashOut *SHA256Output, data []byte) {
+	h.hasher.Reset()
+	h.hasher.Write(data)
+	// Use the `storage` array as storage, but set its size to zero.
+	*hashOut = SHA256Output(h.hasher.Sum((*hashOut)[:0]))
+}
+
+func (h *Hasher) HashCopy(data []byte) SHA256Output {
+	h.Hash(&(h.storage), data)
+	// Returns a copy so that this function can be called several times and not overwrite.
+	return h.storage
 }

--- a/pkg/common/hasher_test.go
+++ b/pkg/common/hasher_test.go
@@ -157,7 +157,7 @@ func doSha256(data []byte) []byte {
 	return hasher.Sum(nil)
 }
 
-func checkSequentialValues(t require.TestingT, IDs []*SHA256Output) {
+func checkSequentialValues(t require.TestingT, IDs []SHA256Output) {
 	i := 0
 	for _, id := range IDs {
 		for _, j := range id {

--- a/pkg/common/hasher_test.go
+++ b/pkg/common/hasher_test.go
@@ -1,11 +1,15 @@
 package common
 
 import (
+	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/netsec-ethz/fpki/pkg/tests"
 )
 
 // TestEmptyHash checks that the hash of anything is always something.
@@ -48,6 +52,111 @@ func TestBytesToIDSequenceAndBack(t *testing.T) {
 	require.Equal(t, newSequence(), sequence)
 }
 
+func TestHasher(t *testing.T) {
+	// Prepare test data and expected results.
+	data := [2][]byte{
+		randomBytes(t, 300),
+		randomBytes(t, 301),
+	}
+	expected := [2][]byte{
+		doSha256(data[0]),
+		doSha256(data[1]),
+	}
+	var results [2]SHA256Output
+
+	h := NewHasher()
+	var storage SHA256Output
+
+	// Test the hasher.
+	h.Hash(&storage, data[0])
+	results[0] = storage
+	require.Equal(t, expected[0], results[0][:])
+
+	// Again, to check that storage is not overwritten and previous value is still valid.
+	h.Hash(&storage, data[1])
+	results[1] = storage
+	require.Equal(t, expected[1], results[1][:])
+	require.Equal(t, expected[0], results[0][:])
+}
+
+func TestHasherCopy(t *testing.T) {
+	// Prepare test data and expected results.
+	data := [2][]byte{
+		randomBytes(t, 300),
+		randomBytes(t, 301),
+	}
+	expected := [2][]byte{
+		doSha256(data[0]),
+		doSha256(data[1]),
+	}
+	var results [2]SHA256Output
+
+	// Test the hasher.
+	h := NewHasher()
+	results[0] = h.HashCopy(data[0])
+	require.Equal(t, expected[0], results[0][:])
+
+	// Again, to check that storage is not overwritten and previous value is still valid.
+	results[1] = h.HashCopy(data[1])
+	require.Equal(t, expected[1], results[1][:])
+	require.Equal(t, expected[0], results[0][:])
+}
+
+func TestHasherAllocations(t *testing.T) {
+	// Prepare test data.
+	data := randomBytes(t, 1_000_000)
+
+	// Prepare the call to measure.
+	var ownStorage SHA256Output
+	h := NewHasher()
+
+	// Check allocations when we hash.
+	allocs := testing.AllocsPerRun(100, func() {
+		h.Hash(&ownStorage, data)
+	})
+
+	require.Equal(t, 0.0, allocs)
+}
+
+func BenchmarkHashFunction(b *testing.B) {
+	b.ReportAllocs()
+	data := randomBytes(b, 4096) // 4K data
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		SHA256Hash32Bytes(data)
+	}
+}
+
+func BenchmarkHasher(b *testing.B) {
+	b.ReportAllocs()
+	data := randomBytes(b, 4096) // 4K data
+	h := NewHasher()
+	var storage SHA256Output
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		h.Hash(&storage, data)
+	}
+}
+
+func BenchmarkHasherCopy(b *testing.B) {
+	b.ReportAllocs()
+	data := randomBytes(b, 4096) // 4K data
+	h := NewHasher()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		h.HashCopy(data)
+	}
+}
+
+func doSha256(data []byte) []byte {
+	hasher := sha256.New()
+	hasher.Write(data)
+	return hasher.Sum(nil)
+}
+
 func checkSequentialValues(t require.TestingT, IDs []*SHA256Output) {
 	i := 0
 	for _, id := range IDs {
@@ -64,4 +173,14 @@ func newSequence() []byte {
 		sequence[i] = byte(i)
 	}
 	return sequence
+}
+
+func randomBytes(t tests.T, size int) []byte {
+	// TODO: reuse random.RandomBytesForTest. Needs refactoring of the util package into
+	// independent-from-data-structures part and dependent-on-common-package.
+	buff := make([]byte, size)
+	n, err := rand.Read(buff)
+	require.NoError(t, err)
+	require.Equal(t, size, n)
+	return buff
 }

--- a/pkg/common/ids.go
+++ b/pkg/common/ids.go
@@ -8,17 +8,16 @@ import (
 // BytesToIDs takes a sequence of bytes and returns a slice of IDs, where the byte sequence
 // is a set of N blocks of ID size.
 // The function expects the sequence to be the correct length (or panic).
-func BytesToIDs(buff []byte) []*SHA256Output {
+func BytesToIDs(buff []byte) []SHA256Output {
 	N := len(buff) / SHA256Size
-	IDs := make([]*SHA256Output, N)
+	IDs := make([]SHA256Output, N)
 	for i := 0; i < N; i++ {
-		id := *(*SHA256Output)(buff[i*SHA256Size : (i+1)*SHA256Size])
-		IDs[i] = &id
+		IDs[i] = *(*SHA256Output)(buff[i*SHA256Size : (i+1)*SHA256Size])
 	}
 	return IDs
 }
 
-func IDsToBytes(IDs []*SHA256Output) []byte {
+func IDsToBytes(IDs []SHA256Output) []byte {
 	// Glue the sorted IDs.
 	gluedIDs := make([]byte, SHA256Size*len(IDs))
 	for i, id := range IDs {
@@ -30,7 +29,7 @@ func IDsToBytes(IDs []*SHA256Output) []byte {
 // SortIDsAndGlue takes a sequence of IDs, sorts them alphabetically, and glues every byte of
 // them together.
 // The IDs are expected to be unique.
-func SortIDsAndGlue(IDs []*SHA256Output) []byte {
+func SortIDsAndGlue(IDs []SHA256Output) []byte {
 	// Copy slice to avoid mutating of the original.
 	ids := append(IDs[:0:0], IDs...)
 	// Sort the IDs.

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -33,11 +33,11 @@ type dirty interface {
 	// A batch will have a implementation dependent size.
 	// Each updated domain represents the SHA256 of the textual domain that was updated and
 	// present in the `updates` table.
-	RetrieveDirtyDomains(ctx context.Context) ([]*common.SHA256Output, error)
+	RetrieveDirtyDomains(ctx context.Context) ([]common.SHA256Output, error)
 
 	// InsertDomainsIntoDirty adds the domain IDs into the dirty table, to signal that these
 	// domains have not been fully processed yet.
-	InsertDomainsIntoDirty(ctx context.Context, ids []*common.SHA256Output) error
+	InsertDomainsIntoDirty(ctx context.Context, ids []common.SHA256Output) error
 
 	// RecomputeDirtyDomainsCertAndPolicyIDs retrieves dirty domains from the dirty list, starting
 	// at firstRow and finishing at lastRow (for a total of lastRow - firstRow + 1 domains),
@@ -54,22 +54,27 @@ type certs interface {
 
 	// CheckCertsExist returns a slice of true/false values. Each value indicates if
 	// the corresponding certificate identified by its ID is already present in the DB.
-	CheckCertsExist(ctx context.Context, ids []*common.SHA256Output) ([]bool, error)
+	CheckCertsExist(ctx context.Context, ids []common.SHA256Output) ([]bool, error)
 
-	UpdateCerts(ctx context.Context, ids, parents []*common.SHA256Output, expirations []*time.Time,
-		payloads [][]byte) error
+	UpdateCerts(
+		ctx context.Context,
+		ids []common.SHA256Output,
+		parents []*common.SHA256Output,
+		expirations []time.Time,
+		payloads [][]byte,
+	) error
 
 	// UpdateDomainCerts updates the domain_certs table with new entries.
-	UpdateDomainCerts(ctx context.Context, domainIDs, certIDs []*common.SHA256Output) error
+	UpdateDomainCerts(ctx context.Context, domainIDs, certIDs []common.SHA256Output) error
 
 	// RetrieveDomainCertificatesIDs retrieves the domain's certificate payload ID and the payload
 	// itself, given the domain ID.
-	RetrieveDomainCertificatesIDs(ctx context.Context, id common.SHA256Output) (
-		certIDsID *common.SHA256Output, certIDs []byte, err error)
+	RetrieveDomainCertificatesIDs(ctx context.Context, id common.SHA256Output,
+	) (certIDsID common.SHA256Output, certIDs []byte, err error)
 
 	// RetrieveCertificatePayloads returns the payload for each of the certificates identified
 	// by the passed ID.
-	RetrieveCertificatePayloads(ctx context.Context, IDs []*common.SHA256Output) ([][]byte, error)
+	RetrieveCertificatePayloads(ctx context.Context, IDs []common.SHA256Output) ([][]byte, error)
 
 	// LastCTlogServerState returns the last state of the CT log server written into the DB.
 	// The url specifies the CT log server from which this data comes from.
@@ -87,27 +92,30 @@ type certs interface {
 type policies interface {
 	// CheckPoliciesExist returns a slice of true/false values. Each value indicates if
 	// the corresponding policy identified by its ID is already present in the DB.
-	CheckPoliciesExist(ctx context.Context, ids []*common.SHA256Output) ([]bool, error)
+	CheckPoliciesExist(ctx context.Context, ids []common.SHA256Output) ([]bool, error)
 
-	UpdatePolicies(ctx context.Context, ids, parents []*common.SHA256Output,
-		expirations []*time.Time, payloads [][]byte) error
+	UpdatePolicies(
+		ctx context.Context,
+		ids []common.SHA256Output,
+		parents []*common.SHA256Output,
+		expirations []time.Time, payloads [][]byte) error
 
 	// UpdateDomainPolicies updates the domain_policies table with new entries.
-	UpdateDomainPolicies(ctx context.Context, domainIDs, policyIDs []*common.SHA256Output) error
+	UpdateDomainPolicies(ctx context.Context, domainIDs, policyIDs []common.SHA256Output) error
 
 	// RetrieveDomainPoliciesIDs returns the policy related payload for a given domain.
 	// This includes the RPCs, SPs, etc.
 	RetrieveDomainPoliciesIDs(ctx context.Context, id common.SHA256Output) (
-		payloadID *common.SHA256Output, payload []byte, err error)
+		payloadID common.SHA256Output, payload []byte, err error)
 
 	// RetrievePolicyPayloads returns the payload for each of the policies identified
 	// by the passed ID.
-	RetrievePolicyPayloads(ctx context.Context, IDs []*common.SHA256Output) ([][]byte, error)
+	RetrievePolicyPayloads(ctx context.Context, IDs []common.SHA256Output) ([][]byte, error)
 }
 
 type certsAndPolicies interface {
 	// RetrieveCertificateOrPolicyPayloads returns the payloads for each identifier regardless whether it is a certificate or a policy
-	RetrieveCertificateOrPolicyPayloads(ctx context.Context, IDs []*common.SHA256Output) ([][]byte, error)
+	RetrieveCertificateOrPolicyPayloads(ctx context.Context, IDs []common.SHA256Output) ([][]byte, error)
 }
 
 // Conn is a connection to operate with the DB.
@@ -127,12 +135,19 @@ type Conn interface {
 	TruncateAllTables(ctx context.Context) error
 
 	// UpdateDomains updates the domains and dirty tables.
-	UpdateDomains(ctx context.Context, domainIDs []*common.SHA256Output, domainNames []string) error
+	UpdateDomains(
+		ctx context.Context,
+		domainIDs []common.SHA256Output,
+		domainNames []string,
+	) error
 
 	// RetrieveDomainEntries: Retrieve a list of domain entries table
-	RetrieveDomainEntries(ctx context.Context, ids []*common.SHA256Output) ([]*KeyValuePair, error)
+	RetrieveDomainEntries(
+		ctx context.Context,
+		ids []common.SHA256Output,
+	) ([]KeyValuePair, error)
 
 	// RetrieveDomainEntriesDirtyOnes returns a list of key-values whose domain IDs are specified
 	// by the dirty table entries starting from `start` and not including `end`.
-	RetrieveDomainEntriesDirtyOnes(ctx context.Context, start, end uint64) ([]*KeyValuePair, error)
+	RetrieveDomainEntriesDirtyOnes(ctx context.Context, start, end uint64) ([]KeyValuePair, error)
 }

--- a/pkg/db/mock_db/conn.go
+++ b/pkg/db/mock_db/conn.go
@@ -44,7 +44,7 @@ func (m *MockConn) EXPECT() *MockConnMockRecorder {
 }
 
 // CheckCertsExist mocks base method.
-func (m *MockConn) CheckCertsExist(arg0 context.Context, arg1 []*common.SHA256Output) ([]bool, error) {
+func (m *MockConn) CheckCertsExist(arg0 context.Context, arg1 []common.SHA256Output) ([]bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckCertsExist", arg0, arg1)
 	ret0, _ := ret[0].([]bool)
@@ -59,7 +59,7 @@ func (mr *MockConnMockRecorder) CheckCertsExist(arg0, arg1 any) *gomock.Call {
 }
 
 // CheckPoliciesExist mocks base method.
-func (m *MockConn) CheckPoliciesExist(arg0 context.Context, arg1 []*common.SHA256Output) ([]bool, error) {
+func (m *MockConn) CheckPoliciesExist(arg0 context.Context, arg1 []common.SHA256Output) ([]bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckPoliciesExist", arg0, arg1)
 	ret0, _ := ret[0].([]bool)
@@ -146,7 +146,7 @@ func (mr *MockConnMockRecorder) DirtyCount(arg0 any) *gomock.Call {
 }
 
 // InsertDomainsIntoDirty mocks base method.
-func (m *MockConn) InsertDomainsIntoDirty(arg0 context.Context, arg1 []*common.SHA256Output) error {
+func (m *MockConn) InsertDomainsIntoDirty(arg0 context.Context, arg1 []common.SHA256Output) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InsertDomainsIntoDirty", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -219,7 +219,7 @@ func (mr *MockConnMockRecorder) RecomputeDirtyDomainsCertAndPolicyIDs(arg0 any) 
 }
 
 // RetrieveCertificateOrPolicyPayloads mocks base method.
-func (m *MockConn) RetrieveCertificateOrPolicyPayloads(arg0 context.Context, arg1 []*common.SHA256Output) ([][]byte, error) {
+func (m *MockConn) RetrieveCertificateOrPolicyPayloads(arg0 context.Context, arg1 []common.SHA256Output) ([][]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RetrieveCertificateOrPolicyPayloads", arg0, arg1)
 	ret0, _ := ret[0].([][]byte)
@@ -234,7 +234,7 @@ func (mr *MockConnMockRecorder) RetrieveCertificateOrPolicyPayloads(arg0, arg1 a
 }
 
 // RetrieveCertificatePayloads mocks base method.
-func (m *MockConn) RetrieveCertificatePayloads(arg0 context.Context, arg1 []*common.SHA256Output) ([][]byte, error) {
+func (m *MockConn) RetrieveCertificatePayloads(arg0 context.Context, arg1 []common.SHA256Output) ([][]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RetrieveCertificatePayloads", arg0, arg1)
 	ret0, _ := ret[0].([][]byte)
@@ -249,10 +249,10 @@ func (mr *MockConnMockRecorder) RetrieveCertificatePayloads(arg0, arg1 any) *gom
 }
 
 // RetrieveDirtyDomains mocks base method.
-func (m *MockConn) RetrieveDirtyDomains(arg0 context.Context) ([]*common.SHA256Output, error) {
+func (m *MockConn) RetrieveDirtyDomains(arg0 context.Context) ([]common.SHA256Output, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RetrieveDirtyDomains", arg0)
-	ret0, _ := ret[0].([]*common.SHA256Output)
+	ret0, _ := ret[0].([]common.SHA256Output)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -264,10 +264,10 @@ func (mr *MockConnMockRecorder) RetrieveDirtyDomains(arg0 any) *gomock.Call {
 }
 
 // RetrieveDomainCertificatesIDs mocks base method.
-func (m *MockConn) RetrieveDomainCertificatesIDs(arg0 context.Context, arg1 common.SHA256Output) (*common.SHA256Output, []byte, error) {
+func (m *MockConn) RetrieveDomainCertificatesIDs(arg0 context.Context, arg1 common.SHA256Output) (common.SHA256Output, []byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RetrieveDomainCertificatesIDs", arg0, arg1)
-	ret0, _ := ret[0].(*common.SHA256Output)
+	ret0, _ := ret[0].(common.SHA256Output)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -280,10 +280,10 @@ func (mr *MockConnMockRecorder) RetrieveDomainCertificatesIDs(arg0, arg1 any) *g
 }
 
 // RetrieveDomainEntries mocks base method.
-func (m *MockConn) RetrieveDomainEntries(arg0 context.Context, arg1 []*common.SHA256Output) ([]*db.KeyValuePair, error) {
+func (m *MockConn) RetrieveDomainEntries(arg0 context.Context, arg1 []common.SHA256Output) ([]db.KeyValuePair, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RetrieveDomainEntries", arg0, arg1)
-	ret0, _ := ret[0].([]*db.KeyValuePair)
+	ret0, _ := ret[0].([]db.KeyValuePair)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -295,10 +295,10 @@ func (mr *MockConnMockRecorder) RetrieveDomainEntries(arg0, arg1 any) *gomock.Ca
 }
 
 // RetrieveDomainEntriesDirtyOnes mocks base method.
-func (m *MockConn) RetrieveDomainEntriesDirtyOnes(arg0 context.Context, arg1, arg2 uint64) ([]*db.KeyValuePair, error) {
+func (m *MockConn) RetrieveDomainEntriesDirtyOnes(arg0 context.Context, arg1, arg2 uint64) ([]db.KeyValuePair, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RetrieveDomainEntriesDirtyOnes", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]*db.KeyValuePair)
+	ret0, _ := ret[0].([]db.KeyValuePair)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -310,10 +310,10 @@ func (mr *MockConnMockRecorder) RetrieveDomainEntriesDirtyOnes(arg0, arg1, arg2 
 }
 
 // RetrieveDomainPoliciesIDs mocks base method.
-func (m *MockConn) RetrieveDomainPoliciesIDs(arg0 context.Context, arg1 common.SHA256Output) (*common.SHA256Output, []byte, error) {
+func (m *MockConn) RetrieveDomainPoliciesIDs(arg0 context.Context, arg1 common.SHA256Output) (common.SHA256Output, []byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RetrieveDomainPoliciesIDs", arg0, arg1)
-	ret0, _ := ret[0].(*common.SHA256Output)
+	ret0, _ := ret[0].(common.SHA256Output)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -326,7 +326,7 @@ func (mr *MockConnMockRecorder) RetrieveDomainPoliciesIDs(arg0, arg1 any) *gomoc
 }
 
 // RetrievePolicyPayloads mocks base method.
-func (m *MockConn) RetrievePolicyPayloads(arg0 context.Context, arg1 []*common.SHA256Output) ([][]byte, error) {
+func (m *MockConn) RetrievePolicyPayloads(arg0 context.Context, arg1 []common.SHA256Output) ([][]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RetrievePolicyPayloads", arg0, arg1)
 	ret0, _ := ret[0].([][]byte)
@@ -384,7 +384,7 @@ func (mr *MockConnMockRecorder) TruncateAllTables(arg0 any) *gomock.Call {
 }
 
 // UpdateCerts mocks base method.
-func (m *MockConn) UpdateCerts(arg0 context.Context, arg1, arg2 []*common.SHA256Output, arg3 []*time.Time, arg4 [][]byte) error {
+func (m *MockConn) UpdateCerts(arg0 context.Context, arg1 []common.SHA256Output, arg2 []*common.SHA256Output, arg3 []time.Time, arg4 [][]byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateCerts", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
@@ -398,7 +398,7 @@ func (mr *MockConnMockRecorder) UpdateCerts(arg0, arg1, arg2, arg3, arg4 any) *g
 }
 
 // UpdateDomainCerts mocks base method.
-func (m *MockConn) UpdateDomainCerts(arg0 context.Context, arg1, arg2 []*common.SHA256Output) error {
+func (m *MockConn) UpdateDomainCerts(arg0 context.Context, arg1, arg2 []common.SHA256Output) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateDomainCerts", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -412,7 +412,7 @@ func (mr *MockConnMockRecorder) UpdateDomainCerts(arg0, arg1, arg2 any) *gomock.
 }
 
 // UpdateDomainPolicies mocks base method.
-func (m *MockConn) UpdateDomainPolicies(arg0 context.Context, arg1, arg2 []*common.SHA256Output) error {
+func (m *MockConn) UpdateDomainPolicies(arg0 context.Context, arg1, arg2 []common.SHA256Output) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateDomainPolicies", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -426,7 +426,7 @@ func (mr *MockConnMockRecorder) UpdateDomainPolicies(arg0, arg1, arg2 any) *gomo
 }
 
 // UpdateDomains mocks base method.
-func (m *MockConn) UpdateDomains(arg0 context.Context, arg1 []*common.SHA256Output, arg2 []string) error {
+func (m *MockConn) UpdateDomains(arg0 context.Context, arg1 []common.SHA256Output, arg2 []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateDomains", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -454,7 +454,7 @@ func (mr *MockConnMockRecorder) UpdateLastCTlogServerState(arg0, arg1, arg2, arg
 }
 
 // UpdatePolicies mocks base method.
-func (m *MockConn) UpdatePolicies(arg0 context.Context, arg1, arg2 []*common.SHA256Output, arg3 []*time.Time, arg4 [][]byte) error {
+func (m *MockConn) UpdatePolicies(arg0 context.Context, arg1 []common.SHA256Output, arg2 []*common.SHA256Output, arg3 []time.Time, arg4 [][]byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdatePolicies", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)

--- a/pkg/db/mysql/common.go
+++ b/pkg/db/mysql/common.go
@@ -8,7 +8,9 @@ import (
 
 // RetrievePolicyPayloads returns the payload for each certificate OR policy identified by the IDs
 // parameter, in the same order (element i corresponds to IDs[i]).
-func (c *mysqlDB) RetrieveCertificateOrPolicyPayloads(ctx context.Context, IDs []*common.SHA256Output,
+func (c *mysqlDB) RetrieveCertificateOrPolicyPayloads(
+	ctx context.Context,
+	IDs []common.SHA256Output,
 ) ([][]byte, error) {
 	str := "SELECT policy_id,payload from policies WHERE policy_id IN " +
 		repeatStmt(1, len(IDs)) +
@@ -16,6 +18,7 @@ func (c *mysqlDB) RetrieveCertificateOrPolicyPayloads(ctx context.Context, IDs [
 		repeatStmt(1, len(IDs))
 	params := make([]any, 2*len(IDs))
 	for i, id := range IDs {
+		id := id
 		params[i] = id[:]
 		params[len(IDs)+i] = id[:]
 	}
@@ -37,7 +40,8 @@ func (c *mysqlDB) RetrieveCertificateOrPolicyPayloads(ctx context.Context, IDs [
 	// Sort them in the same order as the IDs.
 	payloads := make([][]byte, len(IDs))
 	for i, id := range IDs {
-		payloads[i] = m[*id]
+		id := id
+		payloads[i] = m[id]
 	}
 
 	return payloads, nil

--- a/pkg/db/mysql/export_test.go
+++ b/pkg/db/mysql/export_test.go
@@ -17,7 +17,7 @@ func NewMysqlDBForTests(db db.Conn) *MysqlDBForTests {
 	}
 }
 
-func (c *MysqlDBForTests) DebugCheckCertsExist(ctx context.Context, ids []*common.SHA256Output,
+func (c *MysqlDBForTests) DebugCheckCertsExist(ctx context.Context, ids []common.SHA256Output,
 	present []bool) error {
 
 	return c.checkCertsExist(ctx, ids, present)
@@ -26,23 +26,23 @@ func (c *MysqlDBForTests) DebugCheckCertsExist(ctx context.Context, ids []*commo
 func (c *MysqlDBForTests) RetrieveDirtyDomainEntriesInDBJoin(
 	ctx context.Context,
 	start, end uint64,
-) ([]*db.KeyValuePair, error) {
+) ([]db.KeyValuePair, error) {
 
 	return c.retrieveDirtyDomainEntriesInDBJoin(ctx, start, end)
 }
 
 func (c *MysqlDBForTests) RetrieveDirtyDomainEntriesParallel(
 	ctx context.Context,
-	domainIDs []*common.SHA256Output,
-) ([]*db.KeyValuePair, error) {
+	domainIDs []common.SHA256Output,
+) ([]db.KeyValuePair, error) {
 
 	return c.retrieveDirtyDomainEntriesParallel(ctx, domainIDs)
 }
 
 func (c *MysqlDBForTests) RetrieveDirtyDomainEntriesSequential(
 	ctx context.Context,
-	domainIDs []*common.SHA256Output,
-) ([]*db.KeyValuePair, error) {
+	domainIDs []common.SHA256Output,
+) ([]db.KeyValuePair, error) {
 
 	return c.retrieveDirtyDomainEntriesSequential(ctx, domainIDs)
 }

--- a/pkg/domain/domain_test.go
+++ b/pkg/domain/domain_test.go
@@ -100,6 +100,7 @@ func TestSplitE2LD(t *testing.T) {
 	}
 
 	for name, v := range test {
+		name, v := name, v
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			result, err := SplitE2LD(v.input)

--- a/pkg/mapserver/common/domainEntry.go
+++ b/pkg/mapserver/common/domainEntry.go
@@ -13,14 +13,14 @@ import (
 // The domain is identified by the SHA256 of the DomainName in the DB.
 type DomainEntry struct {
 	DomainName  string
-	DomainID    *common.SHA256Output // This is the SHA256 of the domain name
-	DomainValue *common.SHA256Output // = SHA256 ( certsPayloadID || polsPayloadID )
+	DomainID    common.SHA256Output // This is the SHA256 of the domain name
+	DomainValue common.SHA256Output // = SHA256 ( certsPayloadID || polsPayloadID )
 
 	// TODO(juagargi) remove the CertsIDsID and PolicyIDsID from here and from the DB.
 
-	CertIDsID   *common.SHA256Output
+	CertIDsID   common.SHA256Output
 	CertIDs     []byte // Includes x509 leafs and trust chains, raw ASN.1 DER.
-	PolicyIDsID *common.SHA256Output
+	PolicyIDsID common.SHA256Output
 	PolicyIDs   []byte // Includes RPCs, SPs, etc. JSON.
 }
 

--- a/pkg/mapserver/logfetcher/locallogfetcher.go
+++ b/pkg/mapserver/logfetcher/locallogfetcher.go
@@ -71,7 +71,7 @@ var _ Fetcher = (*LocalLogFetcher)(nil)
 
 type CertWithChainData struct {
 	CertID        *common.SHA256Output   // The ID (the SHA256) of the certificate.
-	Cert          *ctx509.Certificate    // The payload of the certificate.
+	Cert          ctx509.Certificate     // The payload of the certificate.
 	ChainIDs      []*common.SHA256Output // The trust chain of the certificate.
 	ChainPayloads []*ctx509.Certificate  // The payloads of the chain. Is nil if already cached.
 	Expired       bool
@@ -228,7 +228,7 @@ func (f *LocalLogFetcher) NextBatch(ctx context.Context) bool {
 // The call blocks until a whole batch is available. The last batch may have less elements.
 // Returns nil when there is no more batches, i.e. all certificates have been fetched.
 func (f *LocalLogFetcher) ReturnNextBatch() (
-	certs []*ctx509.Certificate,
+	certs []ctx509.Certificate,
 	chains [][]*ctx509.Certificate,
 	excluded int,
 	err error) {
@@ -330,7 +330,7 @@ func (p *LocalLogFetcher) ingestWithCSV(fileReader io.Reader) error {
 			chainIDs[i] = &id
 		}
 		p.certWithChainChan <- &CertWithChainData{
-			Cert:          cert,
+			Cert:          *cert,
 			CertID:        &certID,
 			ChainPayloads: chain,
 			ChainIDs:      chainIDs,

--- a/pkg/mapserver/logfetcher/logfetcher.go
+++ b/pkg/mapserver/logfetcher/logfetcher.go
@@ -17,7 +17,7 @@ type Fetcher interface {
 	// Like with sql.Rows.Next()
 	NextBatch(ctx context.Context) bool
 	// Like sql.Rows.Scan(...) also returns the number of certificates in the batch that were removed (e.g., due to their expiration time)
-	ReturnNextBatch() ([]*ctx509.Certificate, [][]*ctx509.Certificate, int, error)
+	ReturnNextBatch() ([]ctx509.Certificate, [][]*ctx509.Certificate, int, error)
 }
 
 // State represents the state of a log (in a server) at a given point in time.
@@ -28,7 +28,7 @@ type State struct {
 }
 
 type result struct {
-	certs   []*ctx509.Certificate
+	certs   []ctx509.Certificate
 	chains  [][]*ctx509.Certificate
 	expired int
 	err     error

--- a/pkg/mapserver/logfetcher/logfetcher_test.go
+++ b/pkg/mapserver/logfetcher/logfetcher_test.go
@@ -55,7 +55,7 @@ func TestGetRawEntries(t *testing.T) {
 
 			f, err := NewHttpLogFetcher(testURL)
 			require.NoError(t, err)
-			rawEntries := make([]*ct.LeafEntry, tc.end-tc.start+1)
+			rawEntries := make([]ct.LeafEntry, tc.end-tc.start+1)
 			n, err := f.getRawEntries(rawEntries, tc.start, tc.end)
 			require.NoError(t, err)
 			require.Equal(t, tc.end-tc.start+1, n)
@@ -75,7 +75,7 @@ func TestStoppingGetRawEntries(t *testing.T) {
 		f.StopFetching()
 	}()
 	// Manually call getRawEntries as if called from the parent.
-	leafEntries := make([]*ct.LeafEntry, f.end-f.start+1)
+	leafEntries := make([]ct.LeafEntry, f.end-f.start+1)
 	n, err := f.getRawEntries(leafEntries, f.start, f.end)
 	require.NoError(t, err)
 	require.Equal(t, int64(0), n)
@@ -138,7 +138,7 @@ func TestGetRawEntriesInBatches(t *testing.T) {
 				f.processBatchSize = f.serverBatchSize * 128
 			}
 
-			entries := make([]*ct.LeafEntry, tc.end-tc.start+1)
+			entries := make([]ct.LeafEntry, tc.end-tc.start+1)
 			n, err := f.getRawEntriesInBatches(entries, tc.start, tc.end)
 			require.NoError(t, err)
 			expected := tc.end - tc.start + 1
@@ -166,7 +166,7 @@ func TestStoppingGetRawEntriesInBatches(t *testing.T) {
 	}()
 
 	// Manually call getRawEntriesInBatches as if called from "fetch()".
-	leafEntries := make([]*ct.LeafEntry, f.processBatchSize)
+	leafEntries := make([]ct.LeafEntry, f.processBatchSize)
 	start := f.start
 	end := f.start + f.processBatchSize - 1
 	n, err := f.getRawEntriesInBatches(leafEntries, start, end)
@@ -235,7 +235,7 @@ func TestLogFetcher(t *testing.T) {
 			}
 			f.StartFetching(int64(tc.start), int64(tc.end))
 
-			allCerts := make([]*ctx509.Certificate, 0)
+			allCerts := make([]ctx509.Certificate, 0)
 			allChains := make([][]*ctx509.Certificate, 0)
 			for f.NextBatch(ctx) {
 				certs, chains, _, err := f.ReturnNextBatch()
@@ -268,7 +268,7 @@ func TestTimeoutLogFetcher(t *testing.T) {
 	require.NoError(t, err)
 
 	// Attempt to fetch something really big that would need more than 1 sec.
-	certs, chains, _, err := f.FetchAllCertificates(ctx, 2000, 666000000)
+	certs, chains, _, err := f.FetchAllCertificates(ctx, 2000, 1_000_000)
 	require.Error(t, err)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	require.Len(t, certs, 0)

--- a/pkg/mapserver/mapserver.go
+++ b/pkg/mapserver/mapserver.go
@@ -262,7 +262,7 @@ func (s *MapServer) apiGetPayloads(w http.ResponseWriter, r *http.Request, retur
 			http.StatusBadRequest)
 		return
 	}
-	ids := make([]*common.SHA256Output, len(hexIDs)/common.SHA256Size/2)
+	ids := make([]common.SHA256Output, len(hexIDs)/common.SHA256Size/2)
 	for i := 0; i < len(ids); i++ {
 		h := hexIDs[i*common.SHA256Size*2 : (i+1)*common.SHA256Size*2]
 		id, err := hex.DecodeString(h)
@@ -270,7 +270,7 @@ func (s *MapServer) apiGetPayloads(w http.ResponseWriter, r *http.Request, retur
 			http.Error(w, fmt.Sprintf("not a hexadecimal ID: %s", h), http.StatusBadRequest)
 			return
 		}
-		ids[i] = (*common.SHA256Output)(id)
+		ids[i] = (common.SHA256Output)(id)
 	}
 
 	// Obtain the bytes.

--- a/pkg/mapserver/responder/responder.go
+++ b/pkg/mapserver/responder/responder.go
@@ -84,7 +84,7 @@ func (r *MapResponder) GetProof(ctx context.Context, domainName string,
 		// If it is a proof of presence, obtain the payload.
 		de := &mapCommon.DomainEntry{
 			DomainName: domainPart,
-			DomainID:   &domainPartID,
+			DomainID:   domainPartID,
 		}
 		proofType := mapCommon.PoA
 		if isPoP {
@@ -104,7 +104,7 @@ func (r *MapResponder) GetProof(ctx context.Context, domainName string,
 			allIDs := append(common.BytesToIDs(de.CertIDs), common.BytesToIDs(de.PolicyIDs)...)
 			v := common.SortIDsAndGlue(allIDs)
 			vID := common.SHA256Hash32Bytes(v)
-			de.DomainValue = &vID
+			de.DomainValue = vID
 
 			// TODO(juagargi) the sorting and concatenation should happen inside the DB.
 		}

--- a/pkg/mapserver/responder/responder_test.go
+++ b/pkg/mapserver/responder/responder_test.go
@@ -144,7 +144,7 @@ func checkProof(t *testing.T, payloadID *common.SHA256Output, proofs []*mapcommo
 			// The ID passed as argument must be one of the IDs present in the domain entry.
 			allIDs := append(common.BytesToIDs(proof.DomainEntry.CertIDs),
 				common.BytesToIDs(proof.DomainEntry.PolicyIDs)...)
-			require.Contains(t, allIDs, payloadID)
+			require.Contains(t, allIDs, *payloadID)
 		}
 	}
 }

--- a/pkg/mapserver/updater/export_test.go
+++ b/pkg/mapserver/updater/export_test.go
@@ -1,0 +1,45 @@
+package updater
+
+import (
+	"time"
+
+	"github.com/netsec-ethz/fpki/pkg/common"
+)
+
+func (w *CertWorker) ExtractDomains(certs []Certificate) []DirtyDomain {
+	w.extractDomains(certs)
+	return w.cacheDomains
+}
+
+func (w *CertWorker) ProcessBundle(certs []Certificate) error {
+	return w.processBundle(certs)
+}
+
+func (w *CertWorker) CloneCerts() []common.SHA256Output {
+	return w.cacheIds
+}
+func (w *CertWorker) CloneParents() []*common.SHA256Output {
+	return w.cacheParents
+}
+func (w *CertWorker) CloneExpirations() []time.Time {
+	return w.cacheExpirations
+}
+func (w *CertWorker) ClonePayloads() [][]byte {
+	return w.cachePayloads
+}
+
+func (w *DomainWorker) ProcessBundle(domains []DirtyDomain) error {
+	return w.processBundle(domains)
+}
+
+func (w *DomainWorker) CloneDomainIDs() []common.SHA256Output {
+	return w.cloneDomainIDs
+}
+
+func (w *DomainWorker) CloneNames() []string {
+	return w.cloneNames
+}
+
+func (w *DomainWorker) CloneCertIDs() []common.SHA256Output {
+	return w.cloneCertIDs
+}

--- a/pkg/mapserver/updater/types.go
+++ b/pkg/mapserver/updater/types.go
@@ -13,33 +13,33 @@ import (
 type CertWithChainData struct {
 	CertID        *common.SHA256Output   // The ID (the SHA256) of the certificate.
 	Cert          *ctx509.Certificate    // The payload of the certificate.
-	ChainIDs      []*common.SHA256Output // The trust chain of the certificate.
 	ChainPayloads []*ctx509.Certificate  // The payloads of the chain. Is nil if already cached.
+	ChainIDs      []*common.SHA256Output // The trust chain of the certificate.
 }
 
 // Certificate contains all the data of just ONE certificate, without the parents.
 // It results from a call to util.UnfoldCert .
 type Certificate struct {
-	CertID   *common.SHA256Output
-	Cert     *ctx509.Certificate
+	CertID   common.SHA256Output
+	Cert     ctx509.Certificate
 	ParentID *common.SHA256Output
 	Names    []string
 }
 
 type DirtyDomain struct {
-	DomainID *common.SHA256Output
-	CertID   *common.SHA256Output
+	DomainID common.SHA256Output
+	CertID   common.SHA256Output
 	Name     string
 }
 
-func CertificatesFromChains(data *CertWithChainData) []*Certificate {
+func CertificatesFromChains(data *CertWithChainData) []Certificate {
 	payloads, certIDs, parentIDs, names := util.UnfoldCert(data.Cert, data.CertID,
 		data.ChainPayloads, data.ChainIDs)
 
-	certs := make([]*Certificate, len(payloads))
+	certs := make([]Certificate, len(payloads))
 	for i := range payloads {
 		// Add the certificate.
-		certs[i] = &Certificate{
+		certs[i] = Certificate{
 			CertID:   certIDs[i],
 			Cert:     payloads[i],
 			ParentID: parentIDs[i],

--- a/pkg/mapserver/updater/updater.go
+++ b/pkg/mapserver/updater/updater.go
@@ -194,16 +194,16 @@ func (u *MapUpdater) UpdateCertsLocally(
 	certChainList [][][]byte,
 ) error {
 
-	expirations := make([]*time.Time, 0, len(certList))
-	certs := make([]*ctx509.Certificate, 0, len(certList))
+	expirations := make([]time.Time, 0, len(certList))
+	certs := make([]ctx509.Certificate, 0, len(certList))
 	certChains := make([][]*ctx509.Certificate, 0, len(certList))
 	for i, certRaw := range certList {
 		cert, err := ctx509.ParseCertificate(certRaw)
 		if err != nil {
 			return err
 		}
-		certs = append(certs, cert)
-		expirations = append(expirations, &cert.NotAfter)
+		certs = append(certs, *cert)
+		expirations = append(expirations, cert.NotAfter)
 
 		chain := make([]*ctx509.Certificate, len(certChainList[i]))
 		for i, certChainItemRaw := range certChainList[i] {
@@ -273,7 +273,7 @@ func (u *MapUpdater) startNextFetcher(ctx context.Context, updateStartTime time.
 
 func (u *MapUpdater) verifyValidity(
 	ctx context.Context,
-	leafCerts []*ctx509.Certificate,
+	leafCerts []ctx509.Certificate,
 	chains [][]*ctx509.Certificate,
 ) error {
 
@@ -288,7 +288,7 @@ func (u *MapUpdater) verifyValidity(
 
 func (u *MapUpdater) updateCertBatch(
 	ctx context.Context,
-	leafCerts []*ctx509.Certificate,
+	leafCerts []ctx509.Certificate,
 	chains [][]*ctx509.Certificate,
 ) error {
 
@@ -325,8 +325,10 @@ func (u *MapUpdater) updatePolicyCerts(
 }
 
 func UpdateWithOverwrite(ctx context.Context, conn db.Conn, domainNames [][]string,
-	certIDs, parentCertIDs []*common.SHA256Output,
-	certs []*ctx509.Certificate, certExpirations []*time.Time,
+	certIDs []common.SHA256Output,
+	parentCertIDs []*common.SHA256Output,
+	certs []ctx509.Certificate,
+	certExpirations []time.Time,
 	policies []common.PolicyDocument,
 ) error {
 
@@ -343,7 +345,7 @@ func UpdateWithOverwrite(ctx context.Context, conn db.Conn, domainNames [][]stri
 
 	// Insert all specified policies.
 	payloads = make([][]byte, len(policies))
-	policyIDs := make([]*common.SHA256Output, len(policies))
+	policyIDs := make([]common.SHA256Output, len(policies))
 	policySubjects := make([]string, len(policies))
 	for i, pol := range policies {
 		payload, err := common.ToJSON(pol)
@@ -351,8 +353,7 @@ func UpdateWithOverwrite(ctx context.Context, conn db.Conn, domainNames [][]stri
 			return err
 		}
 		payloads[i] = payload
-		id := common.SHA256Hash32Bytes(payload)
-		policyIDs[i] = &id
+		policyIDs[i] = common.SHA256Hash32Bytes(payload)
 		policySubjects[i] = pol.Domain()
 	}
 	err = insertPolicies(ctx, conn, policySubjects, policyIDs, payloads)
@@ -360,9 +361,14 @@ func UpdateWithOverwrite(ctx context.Context, conn db.Conn, domainNames [][]stri
 	return err
 }
 
-func UpdateWithKeepExisting(ctx context.Context, conn db.Conn, domainNames [][]string,
-	certIDs, parentCertIDs []*common.SHA256Output,
-	certs []*ctx509.Certificate, certExpirations []*time.Time,
+func UpdateWithKeepExisting(
+	ctx context.Context,
+	conn db.Conn,
+	domainNames [][]string,
+	certIDs []common.SHA256Output,
+	parentCertIDs []*common.SHA256Output,
+	certs []ctx509.Certificate,
+	certExpirations []time.Time,
 	policies []common.PolicyDocument,
 ) error {
 
@@ -394,7 +400,7 @@ func UpdateWithKeepExisting(ctx context.Context, conn db.Conn, domainNames [][]s
 
 	// Prepare data structures for the policies.
 	payloads = make([][]byte, len(policies))
-	policyIDs := make([]*common.SHA256Output, len(policies))
+	policyIDs := make([]common.SHA256Output, len(policies))
 	policySubjects := make([]string, len(policies))
 	for i, pol := range policies {
 		payload, err := pol.Raw()
@@ -402,8 +408,7 @@ func UpdateWithKeepExisting(ctx context.Context, conn db.Conn, domainNames [][]s
 			return err
 		}
 		payloads[i] = payload
-		id := common.SHA256Hash32Bytes(payload)
-		policyIDs[i] = &id
+		policyIDs[i] = common.SHA256Hash32Bytes(payload)
 		policySubjects[i] = pol.Domain()
 	}
 	// Check which policies are already present in the DB.
@@ -471,7 +476,7 @@ func updateSMTfromDomains(
 	ctx context.Context,
 	conn db.Conn,
 	smtTrie *trie.Trie,
-	domainIDs []*common.SHA256Output,
+	domainIDs []common.SHA256Output,
 	max_bundle_size int,
 ) error {
 
@@ -501,7 +506,7 @@ func updateSMTfromDomains(
 func updateSMTfromKeyValues(
 	ctx context.Context,
 	smtTrie *trie.Trie,
-	entries []*db.KeyValuePair,
+	entries []db.KeyValuePair,
 ) error {
 
 	// Adapt data type.
@@ -589,8 +594,15 @@ func loadRoot(ctx context.Context, conn db.Conn) ([]byte, error) {
 	return root, nil
 }
 
-func insertCerts(ctx context.Context, conn db.Conn, names [][]string,
-	ids, parentIDs []*common.SHA256Output, expirations []*time.Time, payloads [][]byte) error {
+func insertCerts(
+	ctx context.Context,
+	conn db.Conn,
+	names [][]string,
+	ids []common.SHA256Output,
+	parentIDs []*common.SHA256Output,
+	expirations []time.Time,
+	payloads [][]byte,
+) error {
 
 	if len(ids) == 0 {
 		return nil
@@ -605,8 +617,8 @@ func insertCerts(ctx context.Context, conn db.Conn, names [][]string,
 	// Add new entries from names into the domains table iff they are leaves.
 	estimatedSize := len(ids) * 2 // Number of IDs / 3 ~~ is the number of leaves. 6 names per leaf.
 	newNames := make([]string, 0, estimatedSize)
-	newIDs := make([]*common.SHA256Output, 0, estimatedSize)
-	domainIDs := make([]*common.SHA256Output, 0, estimatedSize)
+	newIDs := make([]common.SHA256Output, 0, estimatedSize)
+	domainIDs := make([]common.SHA256Output, 0, estimatedSize)
 	for i, names := range names {
 		// Iff the certificate is a leaf certificate it will have a non-nil names slice: insert
 		// one entry per name.
@@ -614,7 +626,7 @@ func insertCerts(ctx context.Context, conn db.Conn, names [][]string,
 			newNames = append(newNames, name)
 			newIDs = append(newIDs, ids[i])
 			domainID := common.SHA256Hash32Bytes([]byte(name))
-			domainIDs = append(domainIDs, &domainID)
+			domainIDs = append(domainIDs, domainID)
 		}
 	}
 	// Push the changes of the domains to the DB.
@@ -632,7 +644,7 @@ func insertCerts(ctx context.Context, conn db.Conn, names [][]string,
 	return nil
 }
 
-func insertPolicies(ctx context.Context, conn db.Conn, names []string, ids []*common.SHA256Output,
+func insertPolicies(ctx context.Context, conn db.Conn, names []string, ids []common.SHA256Output,
 	payloads [][]byte) error {
 
 	if len(ids) == 0 {
@@ -642,10 +654,9 @@ func insertPolicies(ctx context.Context, conn db.Conn, names []string, ids []*co
 	// TODO(juagargi) use parent IDs for the policies
 
 	// Push the changes of the domains to the DB.
-	domainIDs := make([]*common.SHA256Output, len(names))
+	domainIDs := make([]common.SHA256Output, len(names))
 	for i, name := range names {
-		domainID := common.SHA256Hash32Bytes([]byte(name))
-		domainIDs[i] = &domainID
+		domainIDs[i] = common.SHA256Hash32Bytes([]byte(name))
 	}
 
 	if err := conn.InsertDomainsIntoDirty(ctx, domainIDs); err != nil {
@@ -659,10 +670,10 @@ func insertPolicies(ctx context.Context, conn db.Conn, names []string, ids []*co
 	// Sequence of nil parent ids:
 	parents := make([]*common.SHA256Output, len(ids))
 	// Sequence of expiration times way in the future:
-	expirations := make([]*time.Time, len(ids))
+	expirations := make([]time.Time, len(ids))
 	for i := range expirations {
 		t := time.Date(3000, 1, 1, 0, 0, 0, 0, time.UTC) // TODO(juagargi) use real expirations.
-		expirations[i] = &t
+		expirations[i] = t
 	}
 	// Update policies:
 	if err := conn.UpdatePolicies(ctx, ids, parents, expirations, payloads); err != nil {
@@ -693,7 +704,7 @@ func runWhenFalse(mask []bool, fcn func(to, from int)) int {
 // deleteme TODO this function takes the payload and computes the hash of it. The hash is already
 // stored in the DB with the new design: change both the function RetrieveDomainEntries and
 // remove the hashing from this keyValuePairToSMTInput function.
-func keyValuePairToSMTInput(keyValuePair []*db.KeyValuePair) ([][]byte, [][]byte, error) {
+func keyValuePairToSMTInput(keyValuePair []db.KeyValuePair) ([][]byte, [][]byte, error) {
 	type inputPair struct {
 		Key   [32]byte
 		Value []byte

--- a/pkg/tests/random/random_test.go
+++ b/pkg/tests/random/random_test.go
@@ -62,8 +62,9 @@ func TestBuildTestRandomCertHierarchy(t *testing.T) {
 		"a.com",
 		"b.com",
 	}
-	var certs []*ctx509.Certificate
-	var certIDs, parentCertIDs []*common.SHA256Output
+	var certs []ctx509.Certificate
+	var certIDs []common.SHA256Output
+	var parentCertIDs []*common.SHA256Output
 	var certNames [][]string
 	nonLeafCerts := make([]*ctx509.Certificate, 0, len(certs)/2)
 	for _, leaf := range leafs {
@@ -89,12 +90,12 @@ func TestBuildTestRandomCertHierarchy(t *testing.T) {
 
 		// Parents
 		nilPtr := (*common.SHA256Output)(nil)
-		require.Equal(t, nilPtr, parentCertIDs2[0])      // parent(c0)=nil
-		require.Equal(t, certIDs2[0], parentCertIDs2[1]) // parent(c1)=c0
-		require.Equal(t, certIDs2[1], parentCertIDs2[2]) // parent(leaf1)=c1
-		require.Equal(t, certIDs2[0], parentCertIDs2[3]) // parent(leaf2)=c0
+		require.Equal(t, nilPtr, parentCertIDs2[0])       // parent(c0)=nil
+		require.Equal(t, &certIDs2[0], parentCertIDs2[1]) // parent(c1)=c0
+		require.Equal(t, &certIDs2[1], parentCertIDs2[2]) // parent(leaf1)=c1
+		require.Equal(t, &certIDs2[0], parentCertIDs2[3]) // parent(leaf2)=c0
 
-		nonLeafCerts = append(nonLeafCerts, certs2[0], certs2[1])
+		nonLeafCerts = append(nonLeafCerts, &certs2[0], &certs2[1])
 
 		certs = append(certs, certs2...)
 		certIDs = append(certIDs, certIDs2...)

--- a/pkg/tests/random/random_test.go
+++ b/pkg/tests/random/random_test.go
@@ -47,6 +47,10 @@ func TestRandomX509Cert(t *testing.T) {
 	c2 := random.RandomX509Cert(t, "a.com")
 	require.NotEmpty(t, c2.Raw)
 	require.NotEqual(t, c1.Raw, c2.Raw)
+
+	// Sizes not too big. Usual certificates are < 4K.
+	require.Less(t, len(c1.Raw), 1024)
+	require.Less(t, len(c2.Raw), 1024)
 }
 
 // TestBuildTestRandomCertHierarchy checks that the function creates two leaf certificates with

--- a/pkg/tests/updater/updater.go
+++ b/pkg/tests/updater/updater.go
@@ -33,30 +33,32 @@ func UpdateDBwithRandomCerts(
 	certsOrPolicies []CertsPoliciesOrBoth,
 ) (
 	// returns:
-	certs []*ctx509.Certificate,
+	certs []ctx509.Certificate,
 	policies []common.PolicyDocument,
-	IDs []*common.SHA256Output,
+	IDs []common.SHA256Output,
 	parentIDs []*common.SHA256Output,
 	names [][]string,
 ) {
 
 	// Prepare the return variables.
-	certs = make([]*ctx509.Certificate, 0, 4*len(domains))
-	IDs = make([]*common.SHA256Output, 0, len(certs))
+	certs = make([]ctx509.Certificate, 0, 4*len(domains))
+	IDs = make([]common.SHA256Output, 0, len(certs))
 	parentIDs = make([]*common.SHA256Output, 0, len(certs))
 	names = make([][]string, 0, len(certs))
 	policies = make([]common.PolicyDocument, 0, len(certs))
 
 	// Generate and insert into DB the requested certificate hierarchies.
 	for i, domain := range domains {
-		var c []*ctx509.Certificate
-		var certIDs, parentCertIDs []*common.SHA256Output
+		var certsPerDomain []ctx509.Certificate
+		var certIDs []common.SHA256Output
+		var parentCertIDs []*common.SHA256Output
 		var domainNames [][]string
 		var pols []common.PolicyDocument
 
 		// Generate random hierarchies depending of the selection.
 		if certsOrPolicies[i] != PoliciesOnly {
-			c, certIDs, parentCertIDs, domainNames = random.BuildTestRandomCertHierarchy(t, domain)
+			certsPerDomain, certIDs, parentCertIDs, domainNames =
+				random.BuildTestRandomCertHierarchy(t, domain)
 		}
 		if certsOrPolicies[i] != CertsOnly {
 			pols = random.BuildTestRandomPolicyHierarchy(t, domain)
@@ -64,11 +66,11 @@ func UpdateDBwithRandomCerts(
 
 		// Insert all generated hierarchies into DB.
 		err := updater.UpdateWithKeepExisting(ctx, conn, domainNames, certIDs, parentCertIDs,
-			c, util.ExtractExpirations(c), pols)
+			certsPerDomain, util.ExtractExpirations(certsPerDomain), pols)
 		require.NoError(t, err)
 
 		// Add to return variables.
-		certs = append(certs, c...)
+		certs = append(certs, certsPerDomain...)
 		IDs = append(IDs, certIDs...)
 		parentIDs = append(parentIDs, parentCertIDs...)
 		names = append(names, domainNames...)

--- a/pkg/util/certReader.go
+++ b/pkg/util/certReader.go
@@ -22,8 +22,8 @@ func NewCertReader(r io.Reader) *CertReader {
 	}
 }
 
-// Read reads as many certificates as the `certs` slice has or end-of-stream.
-func (r *CertReader) Read(certs []*ctx509.Certificate) (int, error) {
+// Read reads as many certificates as the `certs` slice has, or end-of-stream.
+func (r *CertReader) Read(certs []ctx509.Certificate) (int, error) {
 	certPointers := certs
 	for len(certPointers) > 0 {
 		// Move len(buff) bytes to beginning of storage.
@@ -72,7 +72,7 @@ func (r *CertReader) Read(certs []*ctx509.Certificate) (int, error) {
 					return 0, err
 				}
 			}
-			certPointers[0] = c
+			certPointers[0] = *c
 			certPointers = certPointers[1:]
 		}
 		if r.eofReached {
@@ -84,8 +84,8 @@ func (r *CertReader) Read(certs []*ctx509.Certificate) (int, error) {
 
 // ReadAll reads all pending certificates from the internal reader this CertReader was created
 // from. This function is usually called right after creating the CertReader.
-func (r *CertReader) ReadAll() ([]*ctx509.Certificate, error) {
-	certs := make([]*ctx509.Certificate, 1)
+func (r *CertReader) ReadAll() ([]ctx509.Certificate, error) {
+	certs := make([]ctx509.Certificate, 1)
 	for {
 		n, err := r.Read(certs[len(certs)-1:]) // read one certificate, at the end of the slice
 		if err != nil {
@@ -95,7 +95,7 @@ func (r *CertReader) ReadAll() ([]*ctx509.Certificate, error) {
 			certs = certs[:len(certs)-1] // remove the empty gap
 			break
 		}
-		certs = append(certs, nil) // make room for one more, with an empty gap
+		certs = append(certs, ctx509.Certificate{}) // make room for one more, with an empty gap
 	}
 	return certs, nil
 }

--- a/pkg/util/certReader_test.go
+++ b/pkg/util/certReader_test.go
@@ -13,7 +13,7 @@ func TestCertReader(t *testing.T) {
 	require.NoError(t, err)
 
 	N := 10
-	certs := make([]*ctx509.Certificate, N)
+	certs := make([]ctx509.Certificate, N)
 	r := NewCertReader(z)
 	n, err := r.Read(certs)
 	require.NoError(t, err)
@@ -29,21 +29,21 @@ func TestCertReader(t *testing.T) {
 	require.NoError(t, err)
 
 	N = 10
-	certs = make([]*ctx509.Certificate, N)
+	certs = make([]ctx509.Certificate, N)
 	r = NewCertReader(z)
 	n, err = r.Read(certs)
 	require.NoError(t, err)
 	require.Equal(t, N, n)
 
 	N = 20
-	certs = make([]*ctx509.Certificate, N)
+	certs = make([]ctx509.Certificate, N)
 	r = NewCertReader(z)
 	n, err = r.Read(certs)
 	require.NoError(t, err)
 	require.Equal(t, N, n)
 
 	N = 5
-	certs = make([]*ctx509.Certificate, N)
+	certs = make([]ctx509.Certificate, N)
 	r = NewCertReader(z)
 	n, err = r.Read(certs)
 	require.NoError(t, err)
@@ -54,7 +54,7 @@ func TestCertReader(t *testing.T) {
 	require.NoError(t, err)
 	// Read them all.
 	N = 100000 - 1
-	certs = make([]*ctx509.Certificate, N)
+	certs = make([]ctx509.Certificate, N)
 	r = NewCertReader(z)
 	n, err = r.Read(certs)
 	require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestCertReaderOneByOne(t *testing.T) {
 	r := NewCertReader(f)
 	N := 3
 
-	cs := make([]*ctx509.Certificate, 1)
+	cs := make([]ctx509.Certificate, 1)
 	for i := 0; i < N; i++ {
 		t.Logf("iteration %d", i)
 		n, err := r.Read(cs)
@@ -105,7 +105,7 @@ func TestCertReaderReadAll(t *testing.T) {
 	f, err = os.Open("../../tests/testdata/3-certs.pem")
 	require.NoError(t, err)
 	r = NewCertReader(f)
-	threeCerts := make([]*ctx509.Certificate, N)
+	threeCerts := make([]ctx509.Certificate, N)
 	n, err := r.Read(threeCerts)
 	require.Equal(t, N, n)
 	require.NoError(t, err)

--- a/pkg/util/certWriter.go
+++ b/pkg/util/certWriter.go
@@ -18,7 +18,7 @@ func NewCertWriter(w io.Writer) *CertWriter {
 }
 
 // Write acts like a io.Writer Write method, but for certificates.
-func (w *CertWriter) Write(certs []*ctx509.Certificate) (int, error) {
+func (w *CertWriter) Write(certs []ctx509.Certificate) (int, error) {
 	for i, c := range certs {
 		b := &pem.Block{
 			Type:  "CERTIFICATE",

--- a/pkg/util/certWriter_test.go
+++ b/pkg/util/certWriter_test.go
@@ -15,7 +15,7 @@ func TestCertWriter(t *testing.T) {
 	// Load three certificates.
 	N := 3
 	r := NewCertReader(bytes.NewBuffer(payload))
-	certs := make([]*ctx509.Certificate, N)
+	certs := make([]ctx509.Certificate, N)
 	n, err := r.Read(certs)
 	require.NoError(t, err)
 	require.Equal(t, N, n)

--- a/pkg/util/certificate.go
+++ b/pkg/util/certificate.go
@@ -11,25 +11,25 @@ import (
 
 // ExtractNames returns a list of lists of names. Since each certificate contains several names,
 // the function returns a collection of slices of names, extracted from each certificate's SAN.
-func ExtractNames(certs []*ctx509.Certificate) [][]string {
+func ExtractNames(certs []ctx509.Certificate) [][]string {
 	names := make([][]string, len(certs))
 	for i, c := range certs {
-		names[i] = ExtractCertDomains(c)
+		names[i] = ExtractCertDomains(&c)
 	}
 	return names
 }
 
 // ExtractExpirations returns all expiration times in order.
-func ExtractExpirations(certs []*ctx509.Certificate) []*time.Time {
-	expirations := make([]*time.Time, len(certs))
+func ExtractExpirations(certs []ctx509.Certificate) []time.Time {
+	expirations := make([]time.Time, len(certs))
 	for i, c := range certs {
-		expirations[i] = &c.NotAfter
+		expirations[i] = c.NotAfter
 	}
 	return expirations
 }
 
 // ExtractPayloads returns the .Raw component of each certificate in order.
-func ExtractPayloads(certs []*ctx509.Certificate) [][]byte {
+func ExtractPayloads(certs []ctx509.Certificate) [][]byte {
 	payloads := make([][]byte, len(certs))
 	for i, c := range certs {
 		payloads[i] = c.Raw
@@ -38,7 +38,7 @@ func ExtractPayloads(certs []*ctx509.Certificate) [][]byte {
 }
 
 // SerializeCertificates serializes a sequence of certificates into their ASN.1 DER form.
-func SerializeCertificates(certs []*ctx509.Certificate) ([]byte, error) {
+func SerializeCertificates(certs []ctx509.Certificate) ([]byte, error) {
 	buff := bytes.NewBuffer(nil)
 	w := NewCertWriter(buff)
 	n, err := w.Write(certs)
@@ -53,7 +53,7 @@ func SerializeCertificates(certs []*ctx509.Certificate) ([]byte, error) {
 
 // DeserializeCertificates takes a stream of bytes that contains a sequence of certificates in
 // ASN.1 DER form, and returns the original sequence of certificates.
-func DeserializeCertificates(payload []byte) ([]*ctx509.Certificate, error) {
+func DeserializeCertificates(payload []byte) ([]ctx509.Certificate, error) {
 	br := bytes.NewReader(payload)
 	r := NewCertReader(br)
 	return r.ReadAll()
@@ -70,10 +70,10 @@ func DeserializeCertificates(payload []byte) ([]*ctx509.Certificate, error) {
 //
 // The leaf certificates are always returned at the head of the slice, which means, among others,
 // that once a nil value is found in the names slice, the rest of the slice will be nil as well.
-func UnfoldCerts(leafCerts []*ctx509.Certificate, chains [][]*ctx509.Certificate,
+func UnfoldCerts(leafCerts []ctx509.Certificate, chains [][]*ctx509.Certificate,
 ) (
-	certificates []*ctx509.Certificate,
-	certIDs []*common.SHA256Output,
+	certificates []ctx509.Certificate,
+	certIDs []common.SHA256Output,
 	parentIDs []*common.SHA256Output,
 	names [][]string,
 ) {
@@ -86,18 +86,18 @@ func UnfoldCerts(leafCerts []*ctx509.Certificate, chains [][]*ctx509.Certificate
 	}
 	// ChangeFcn changes extractNames to always return nil.
 	changeFcn := func() {
-		extractNames = func(c *ctx509.Certificate) []string {
+		extractNames = func(*ctx509.Certificate) []string {
 			return nil
 		}
 	}
 
 	for len(leafCerts) > 0 {
-		var pendingCerts []*ctx509.Certificate
+		var pendingCerts []ctx509.Certificate
 		var pendingChains [][]*ctx509.Certificate
 		for i, c := range leafCerts {
 			certificates = append(certificates, c)
 			ID := common.SHA256Hash32Bytes(c.Raw)
-			certIDs = append(certIDs, &ID)
+			certIDs = append(certIDs, ID)
 			var parentID *common.SHA256Output
 			if len(chains[i]) > 0 {
 				// The certificate has a trust chain (it is not root): add the first certificate
@@ -107,11 +107,11 @@ func UnfoldCerts(leafCerts []*ctx509.Certificate, chains [][]*ctx509.Certificate
 				parentID = &ID
 				// Add this parent to the back of the certs, plus the corresponding chain entry,
 				// so that it's processed as a certificate.
-				pendingCerts = append(pendingCerts, parent)
+				pendingCerts = append(pendingCerts, *parent)
 				pendingChains = append(pendingChains, chains[i][1:])
 			}
 			parentIDs = append(parentIDs, parentID)
-			names = append(names, extractNames(c))
+			names = append(names, extractNames(&c))
 		}
 		changeFcn() // This will change the function `extractNames` to always return nil.
 		leafCerts = pendingCerts
@@ -128,20 +128,20 @@ func UnfoldCerts(leafCerts []*ctx509.Certificate, chains [][]*ctx509.Certificate
 func UnfoldCert(leafCert *ctx509.Certificate, certID *common.SHA256Output,
 	chain []*ctx509.Certificate, chainIDs []*common.SHA256Output,
 ) (
-	certs []*ctx509.Certificate,
-	certIDs []*common.SHA256Output,
+	certs []ctx509.Certificate,
+	certIDs []common.SHA256Output,
 	parentIDs []*common.SHA256Output,
 	names [][]string,
 ) {
 
-	certs = make([]*ctx509.Certificate, 0, len(chainIDs)+1)
-	certIDs = make([]*common.SHA256Output, 0, len(chainIDs)+1)
+	certs = make([]ctx509.Certificate, 0, len(chainIDs)+1)
+	certIDs = make([]common.SHA256Output, 0, len(chainIDs)+1)
 	parentIDs = make([]*common.SHA256Output, 0, len(chainIDs)+1)
 	names = make([][]string, 0, len(chainIDs)+1)
 
 	// Always add the leaf certificate.
-	certs = append(certs, leafCert)
-	certIDs = append(certIDs, certID)
+	certs = append(certs, *leafCert)
+	certIDs = append(certIDs, *certID)
 	parentIDs = append(parentIDs, chainIDs[0])
 	names = append(names, ExtractCertDomains(leafCert))
 	// Add the intermediate certs iff their payload is not nil.
@@ -153,15 +153,15 @@ func UnfoldCert(leafCert *ctx509.Certificate, certID *common.SHA256Output,
 			// There are no more parents to insert.
 			return
 		}
-		certs = append(certs, chain[i])
-		certIDs = append(certIDs, chainIDs[i])
+		certs = append(certs, *chain[i])
+		certIDs = append(certIDs, *chainIDs[i])
 		parentIDs = append(parentIDs, chainIDs[i+1])
 		names = append(names, nil)
 	}
 	// Add the root certificate (no parent) iff we haven't inserted it yet.
 	if chain[i] != nil {
-		certs = append(certs, chain[i])
-		certIDs = append(certIDs, chainIDs[i])
+		certs = append(certs, *chain[i])
+		certIDs = append(certIDs, *chainIDs[i])
 		parentIDs = append(parentIDs, nil)
 		names = append(names, nil)
 	}

--- a/pkg/util/certificate_test.go
+++ b/pkg/util/certificate_test.go
@@ -19,7 +19,7 @@ func TestDeserializeCertificates(t *testing.T) {
 	f, err := os.Open("../../tests/testdata/3-certs.pem")
 	require.NoError(t, err)
 	r := NewCertReader(f)
-	certs := make([]*ctx509.Certificate, N)
+	certs := make([]ctx509.Certificate, N)
 	n, err := r.Read(certs)
 	require.NoError(t, err)
 	require.Equal(t, N, n)
@@ -40,28 +40,28 @@ func TestDeserializeCertificates(t *testing.T) {
 
 func TestUnfoldCerts(t *testing.T) {
 	// `a` and `b` are leaves. `a` is root, `b` has `c`->`d` as its trust chain.
-	a := &ctx509.Certificate{
+	a := ctx509.Certificate{
 		Raw: []byte{0},
 		Subject: pkix.Name{
 			CommonName: "a",
 		},
 		DNSNames: []string{"a", "a", "a.com"},
 	}
-	b := &ctx509.Certificate{
+	b := ctx509.Certificate{
 		Raw: []byte{1},
 		Subject: pkix.Name{
 			CommonName: "b",
 		},
 		DNSNames: []string{"b", "b", "b.com"},
 	}
-	c := &ctx509.Certificate{
+	c := ctx509.Certificate{
 		Raw: []byte{1},
 		Subject: pkix.Name{
 			CommonName: "c",
 		},
 		DNSNames: []string{"c", "c", "c.com"},
 	}
-	d := &ctx509.Certificate{
+	d := ctx509.Certificate{
 		Raw: []byte{3},
 		Subject: pkix.Name{
 			CommonName: "d",
@@ -69,17 +69,17 @@ func TestUnfoldCerts(t *testing.T) {
 		DNSNames: []string{"d", "d", "d.com"},
 	}
 
-	certs := []*ctx509.Certificate{
+	certs := []ctx509.Certificate{
 		a,
 		b,
 	}
 	chains := [][]*ctx509.Certificate{
 		nil,
-		{c, d},
+		{&c, &d},
 	}
 	allCerts, IDs, parentIDs, names := UnfoldCerts(certs, chains)
 
-	fmt.Printf("[%p %p %p %p]\n", a, b, c, d)
+	fmt.Printf("[%p %p %p %p]\n", &a, &b, &c, &d)
 	fmt.Printf("%v\n", allCerts)
 	fmt.Printf("%v\n", IDs)
 	fmt.Printf("%v\n", parentIDs)
@@ -100,10 +100,10 @@ func TestUnfoldCerts(t *testing.T) {
 	cID := common.SHA256Hash32Bytes(c.Raw)
 	dID := common.SHA256Hash32Bytes(d.Raw)
 
-	assert.Equal(t, aID, *IDs[0])
-	assert.Equal(t, bID, *IDs[1])
-	assert.Equal(t, cID, *IDs[2])
-	assert.Equal(t, dID, *IDs[3])
+	assert.Equal(t, aID, IDs[0])
+	assert.Equal(t, bID, IDs[1])
+	assert.Equal(t, cID, IDs[2])
+	assert.Equal(t, dID, IDs[3])
 
 	// Check parent IDs.
 	nilID := (*common.SHA256Output)(nil)

--- a/pkg/util/domain_test.go
+++ b/pkg/util/domain_test.go
@@ -12,7 +12,7 @@ func TestExtractCertDomains(t *testing.T) {
 	require.NoError(t, err)
 	r := NewCertReader(z)
 
-	certs := make([]*ctx509.Certificate, 5)
+	certs := make([]ctx509.Certificate, 5)
 	n, err := r.Read(certs)
 	require.NoError(t, err)
 	require.Equal(t, len(certs), n)
@@ -24,6 +24,6 @@ func TestExtractCertDomains(t *testing.T) {
 		{"www.knocknok-fashion.com", "knocknok-fashion.com"},
 	}
 	for i, names := range names {
-		require.ElementsMatch(t, names, ExtractCertDomains(certs[i]))
+		require.ElementsMatch(t, names, ExtractCertDomains(&certs[i]))
 	}
 }

--- a/pkg/util/io.go
+++ b/pkg/util/io.go
@@ -73,25 +73,25 @@ func CertificateFromPEMFile(filename string) (*ctx509.Certificate, error) {
 		return nil, err
 	}
 	r := NewCertReader(f)
-	certs := make([]*ctx509.Certificate, 1)
+	certs := make([]ctx509.Certificate, 1)
 	_, err = r.Read(certs)
 	if err != nil {
 		return nil, err
 	}
 	// If no certificate was found, certs[0] will be nil.
-	return certs[0], nil
+	return &certs[0], nil
 }
 
 func CertificateFromPEMBytes(pem []byte) (*ctx509.Certificate, error) {
 	f := bytes.NewReader(pem)
 	r := NewCertReader(f)
-	certs := make([]*ctx509.Certificate, 1)
+	certs := make([]ctx509.Certificate, 1)
 	_, err := r.Read(certs)
 	if err != nil {
 		return nil, err
 	}
 	// If no certificate was found, certs[0] will be nil.
-	return certs[0], nil
+	return &certs[0], nil
 }
 
 // RSAKeyFromFile loads an RSA private key from file in PEM format.
@@ -157,8 +157,9 @@ func PolicyCertificateFromBytes(data []byte) (*common.PolicyCertificate, error) 
 // The returned names contains nil unless the corresponding certificate is a leaf certificate.
 func LoadCertsAndChainsFromCSV(
 	fileContents []byte,
-) (payloads []*ctx509.Certificate,
-	IDs []*common.SHA256Output,
+) (
+	payloads []ctx509.Certificate,
+	IDs []common.SHA256Output,
 	parentIDs []*common.SHA256Output,
 	names [][]string,
 	errRet error,
@@ -173,7 +174,7 @@ func LoadCertsAndChainsFromCSV(
 		errRet = err
 		return
 	}
-	leafs := make([]*ctx509.Certificate, 0, len(payloads))
+	leafs := make([]ctx509.Certificate, 0, len(payloads))
 	chains := make([][]*ctx509.Certificate, 0, len(payloads))
 	for _, fields := range records {
 		if len(fields) == 0 {
@@ -185,7 +186,7 @@ func LoadCertsAndChainsFromCSV(
 			errRet = err
 			return
 		}
-		leafs = append(leafs, cert)
+		leafs = append(leafs, *cert)
 
 		// Parse the chain.
 		// The certificate chain is a list of base64 strings separated by semicolon (;).

--- a/tests/integration/mapserver/main.go
+++ b/tests/integration/mapserver/main.go
@@ -148,10 +148,10 @@ func checkResponse(
 	policyIDs := make(map[common.SHA256Output]struct{})
 	for _, p := range proofChain {
 		for _, id := range common.BytesToIDs(p.DomainEntry.CertIDs) {
-			certIDs[*id] = struct{}{}
+			certIDs[id] = struct{}{}
 		}
 		for _, id := range common.BytesToIDs(p.DomainEntry.PolicyIDs) {
-			policyIDs[*id] = struct{}{}
+			policyIDs[id] = struct{}{}
 		}
 	}
 
@@ -244,12 +244,12 @@ func checkIDsInProof(
 		// Certificates.
 		ids := common.BytesToIDs(proofChain[i].DomainEntry.CertIDs)
 		for _, id := range ids {
-			allIDs[*id] = struct{}{}
+			allIDs[id] = struct{}{}
 		}
 		// Policies.
 		ids = common.BytesToIDs(proofChain[i].DomainEntry.PolicyIDs)
 		for _, id := range ids {
-			allIDs[*id] = struct{}{}
+			allIDs[id] = struct{}{}
 		}
 	}
 


### PR DESCRIPTION
In general, using slices of pointers introduces a double indirection.
Only the parent IDs have any reason to be represented as a pointer: if `nil` it means there is no parent.

This PR modifies many lines, but semantically just changes slices like
```go
[]*common.SHA256Output
```
to 
```go
[]common.SHA256Output
```
Some other slices, like those of `[]*ctx509.Certificate` have been adapted as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/fpki/65)
<!-- Reviewable:end -->
