### PR TITLE
Bundle and deadlocks

### DIFF
--- a/cmd/ingest/benchmarks_test.go
+++ b/cmd/ingest/benchmarks_test.go
@@ -94,7 +94,7 @@ func BenchmarkChainsToCert(b *testing.B) {
 		NumToChain: 1,
 	}
 
-	w := NewChainToCertWorker(0)
+	w := NewChainToCertWorker(0, p)
 	w.Prepare(ctx)
 
 	// Mock linking.
@@ -156,7 +156,7 @@ func BenchmarkCertSink(b *testing.B) {
 }
 
 func getManager(t tests.T) *updater.Manager {
-	m, err := updater.NewManager(1, nil, math.MaxInt, math.MaxUint64, nil, time.Hour, nil)
+	m, err := updater.NewManager(1, nil, 10_000, math.MaxUint64, nil, time.Hour, nil)
 	require.NoError(t, err)
 	return m
 }

--- a/cmd/ingest/benchmarks_test.go
+++ b/cmd/ingest/benchmarks_test.go
@@ -18,7 +18,7 @@ func BenchmarkCsvSplit(b *testing.B) {
 	ctx := context.Background()
 	p := &Processor{
 		Ctx:        ctx,
-		stats:      updater.NewStatistics(time.Second, nil),
+		Manager:    getManager(b),
 		NumToChain: 1,
 	}
 
@@ -51,7 +51,7 @@ func BenchmarkLineToChain(b *testing.B) {
 	ctx := context.Background()
 	p := &Processor{
 		Ctx:        ctx,
-		stats:      updater.NewStatistics(time.Second, nil),
+		Manager:    getManager(b),
 		NumToChain: 1,
 	}
 
@@ -90,7 +90,7 @@ func BenchmarkChainsToCert(b *testing.B) {
 	ctx := context.Background()
 	p := &Processor{
 		Ctx:        ctx,
-		stats:      updater.NewStatistics(time.Second, nil),
+		Manager:    getManager(b),
 		NumToChain: 1,
 	}
 
@@ -130,9 +130,8 @@ func BenchmarkCertSink(b *testing.B) {
 	ctx := context.Background()
 	p := &Processor{
 		Ctx:        ctx,
-		stats:      updater.NewStatistics(time.Second, nil),
+		Manager:    getManager(b),
 		NumToChain: 1,
-		BundleSize: math.MaxUint64,
 	}
 
 	w := p.createCertificateSink()
@@ -154,6 +153,12 @@ func BenchmarkCertSink(b *testing.B) {
 	b.Logf("read %d certificates in %s", len(certs), b.Elapsed().String())
 
 	<-w.ErrCh
+}
+
+func getManager(t tests.T) *updater.Manager {
+	m, err := updater.NewManager(1, nil, math.MaxInt, math.MaxUint64, nil, time.Hour, nil)
+	require.NoError(t, err)
+	return m
 }
 
 func getLines(t tests.T, filename string, count int) []line {

--- a/cmd/ingest/chainToCertWorker.go
+++ b/cmd/ingest/chainToCertWorker.go
@@ -15,7 +15,7 @@ type chainToCertWorker struct {
 	channelsCache []int // reuse storage
 }
 
-func NewChainToCertWorker(numWorker int) *chainToCertWorker {
+func NewChainToCertWorker(numWorker int, p *Processor) *chainToCertWorker {
 	w := &chainToCertWorker{}
 	name := fmt.Sprintf("toCerts_%02d", numWorker)
 	w.Stage = pip.NewStage[certChain, updater.Certificate](
@@ -27,6 +27,9 @@ func NewChainToCertWorker(numWorker int) *chainToCertWorker {
 
 			// Recreate channel indices, all to zero.
 			util.ResizeSlice(&w.channelsCache, len(certs), 0)
+
+			// Increment the count of certs.
+			p.certsBeforeBundle.Add(uint64(len(certs)))
 
 			return certs, w.channelsCache, nil
 		}),

--- a/cmd/ingest/csvSplitWorker.go
+++ b/cmd/ingest/csvSplitWorker.go
@@ -55,7 +55,7 @@ func NewCsvSplitWorker(p *Processor) *csvSplitWorker {
 			if !stillLinesToSend {
 				*outs = (*outs)[:0]
 				*outChs = (*outChs)[:0]
-				p.stats.TotalFilesRead.Add(1)
+				p.Manager.Stats.TotalFilesRead.Add(1)
 				return nil
 			}
 			return pip.StreamOutput

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -50,7 +50,7 @@ const (
 //
 // deleteme:
 // debugging:
-// time go run -tags=trace ./cmd/ingest/ -numparsers 1 -numdbworkers 1 -strategy onlyingest ./testdata2/
+// time go run -tags=trace ./cmd/ingest/ -numfiles 1  -numparsers 4 -numdechainers 2 -numdbworkers 4 -strategy onlyingest ./testdata2/
 func main() {
 	os.Exit(mainFunction())
 }

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -69,6 +69,8 @@ func mainFunction() int {
 	}
 	cpuProfile := flag.String("cpuprofile", "", "write a CPU profile to file")
 	memProfile := flag.String("memprofile", "", "write a memory profile to file")
+	multiInsertSize := flag.Int("multiinsert", MultiInsertSize, "number of certificates and "+
+		"domains inserted at once in the DB")
 	bundleSize := flag.Uint64("bundlesize", 0, "number of certificates after which a coalesce and "+
 		"SMT update must occur. If 0, no limit, meaning coalescing and SMT updating is done once")
 	numFiles := flag.Int("numfiles", NumFiles, "Number of parallel files being read at once")
@@ -197,7 +199,7 @@ func mainFunction() int {
 		proc, err := NewProcessor(
 			ctx,
 			conn,
-			MultiInsertSize,
+			*multiInsertSize,
 			2*time.Second,
 			printStats,
 			WithNumFileReaders(*numFiles),

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -196,6 +196,8 @@ func mainFunction() int {
 			}
 		}
 
+		_ = bundleProcessing
+
 		proc, err := NewProcessor(
 			ctx,
 			conn,
@@ -206,8 +208,8 @@ func mainFunction() int {
 			WithNumToChains(*numParsers),
 			WithNumToCerts(*numChainToCerts),
 			WithNumDBWriters(*numDBWriters),
-			WithBundleSize(*bundleSize),
-			WithOnBundleFinished(bundleProcessing),
+			// WithBundleSize(*bundleSize),
+			// WithOnBundleFinished(bundleProcessing),
 		)
 		exitIfError(err)
 

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -208,8 +208,8 @@ func mainFunction() int {
 			WithNumToChains(*numParsers),
 			WithNumToCerts(*numChainToCerts),
 			WithNumDBWriters(*numDBWriters),
-			// WithBundleSize(*bundleSize),
-			// WithOnBundleFinished(bundleProcessing),
+			WithBundleSize(*bundleSize),
+			WithOnBundleFinished(bundleProcessing),
 		)
 		exitIfError(err)
 

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -196,8 +196,6 @@ func mainFunction() int {
 			}
 		}
 
-		_ = bundleProcessing
-
 		proc, err := NewProcessor(
 			ctx,
 			conn,

--- a/cmd/ingest/processor.go
+++ b/cmd/ingest/processor.go
@@ -132,22 +132,22 @@ func WithNumDBWriters(numDBWriters int) ingestOptions {
 		})
 }
 
-func WithBundleSize(bundleSize uint64) ingestOptions {
-	return managerOptions(
-		func(m *updater.Manager) {
-			if bundleSize == 0 {
-				bundleSize = math.MaxUint64
-			}
-			m.BundleSize = bundleSize
-		})
-}
+// func WithBundleSize(bundleSize uint64) ingestOptions {
+// 	return managerOptions(
+// 		func(m *updater.Manager) {
+// 			if bundleSize == 0 {
+// 				bundleSize = math.MaxUint64
+// 			}
+// 			m.BundleSize = bundleSize
+// 		})
+// }
 
-func WithOnBundleFinished(fcn func()) ingestOptions {
-	return managerOptions(
-		func(m *updater.Manager) {
-			m.OnBundleFinished = fcn
-		})
-}
+// func WithOnBundleFinished(fcn func()) ingestOptions {
+// 	return managerOptions(
+// 		func(m *updater.Manager) {
+// 			m.OnBundleFinished = fcn
+// 		})
+// }
 
 func (p *Processor) Resume() {
 	p.Pipeline.Resume(p.Ctx)

--- a/cmd/ingest/toChainPtrWorker.go
+++ b/cmd/ingest/toChainPtrWorker.go
@@ -62,9 +62,9 @@ func (w *lineToChainPtrWorker) parseLine(p *Processor, line *line) (*certChain, 
 	}
 
 	// Update statistics.
-	p.stats.ReadBytes.Add(int64(len(rawBytes)))
-	p.stats.ReadCerts.Add(1)
-	p.stats.UncachedCerts.Add(1)
+	p.Manager.Stats.ReadBytes.Add(int64(len(rawBytes)))
+	p.Manager.Stats.ReadCerts.Add(1)
+	p.Manager.Stats.UncachedCerts.Add(1)
 
 	// Get the leaf certificate ID.
 	certID := common.SHA256Hash32Bytes(rawBytes)
@@ -94,8 +94,8 @@ func (w *lineToChainPtrWorker) parseLine(p *Processor, line *line) (*certChain, 
 				line.number, err, line.fields[CertChainColumn])
 		}
 		// Update statistics.
-		p.stats.ReadBytes.Add(int64(len(rawBytes)))
-		p.stats.ReadCerts.Add(1)
+		p.Manager.Stats.ReadBytes.Add(int64(len(rawBytes)))
+		p.Manager.Stats.ReadCerts.Add(1)
 		// Check if the parent certificate is in the cache.
 		id := common.SHA256Hash32Bytes(rawBytes)
 		if !w.cache.Contains(&id) {
@@ -106,7 +106,7 @@ func (w *lineToChainPtrWorker) parseLine(p *Processor, line *line) (*certChain, 
 					line.number, err, line.fields[CertChainColumn])
 			}
 			w.cache.AddIDs(&id)
-			p.stats.UncachedCerts.Add(1)
+			p.Manager.Stats.UncachedCerts.Add(1)
 		}
 		chainIDs[i] = &id
 	}

--- a/cmd/ingest/toChainWorker.go
+++ b/cmd/ingest/toChainWorker.go
@@ -79,9 +79,9 @@ func (w *lineToChainWorker) parseLine(p *Processor, line *line) (*certChain, err
 	}
 
 	// Update statistics.
-	p.stats.ReadBytes.Add(int64(len(rawBytes)))
-	p.stats.ReadCerts.Add(1)
-	p.stats.UncachedCerts.Add(1)
+	p.Manager.Stats.ReadBytes.Add(int64(len(rawBytes)))
+	p.Manager.Stats.ReadCerts.Add(1)
+	p.Manager.Stats.UncachedCerts.Add(1)
 
 	// Get the leaf certificate ID.
 	certID := common.SHA256Hash32Bytes(rawBytes)
@@ -111,8 +111,8 @@ func (w *lineToChainWorker) parseLine(p *Processor, line *line) (*certChain, err
 				line.number, err, line.fields[CertChainColumn])
 		}
 		// Update statistics.
-		p.stats.ReadBytes.Add(int64(len(rawBytes)))
-		p.stats.ReadCerts.Add(1)
+		p.Manager.Stats.ReadBytes.Add(int64(len(rawBytes)))
+		p.Manager.Stats.ReadCerts.Add(1)
 		// Check if the parent certificate is in the cache.
 		id := common.SHA256Hash32Bytes(rawBytes)
 		if !w.cache.Contains(&id) {
@@ -123,7 +123,7 @@ func (w *lineToChainWorker) parseLine(p *Processor, line *line) (*certChain, err
 					line.number, err, line.fields[CertChainColumn])
 			}
 			w.cache.AddIDs(&id)
-			p.stats.UncachedCerts.Add(1)
+			p.Manager.Stats.UncachedCerts.Add(1)
 		}
 		chainIDs[i] = &id
 	}

--- a/pkg/mapserver/updater/certsWorker.go
+++ b/pkg/mapserver/updater/certsWorker.go
@@ -164,9 +164,6 @@ func newCertInserter(
 	w.Sink = pip.NewSink[CertBatch](
 		fmt.Sprintf("cert_inserter_%02d", id),
 		pip.WithSinkFunction(func(batch CertBatch) error {
-			doneFunc := m.startInserting()
-			defer doneFunc(len(batch))
-
 			// Insert the batch now.
 			return w.insertCertificates(m.Conn, batch)
 		}),

--- a/pkg/mapserver/updater/domainWorker.go
+++ b/pkg/mapserver/updater/domainWorker.go
@@ -145,10 +145,6 @@ func (w *domainInserter) processBatch(batch []DirtyDomain) error {
 		return nil
 	}
 
-	// Announce that there is a new inserter about to modify the DB.
-	doneFunc := w.Manager.startInserting()
-	defer doneFunc(0) // no new certificates inserted.
-
 	{
 		// Flatten data structure.
 		_, span := w.Tracer.Start(ctx, "flatten")

--- a/pkg/mapserver/updater/domainWorker.go
+++ b/pkg/mapserver/updater/domainWorker.go
@@ -145,6 +145,10 @@ func (w *domainInserter) processBatch(batch []DirtyDomain) error {
 		return nil
 	}
 
+	// Announce that there is a new inserter about to modify the DB.
+	doneFunc := w.Manager.startInserting()
+	defer doneFunc(0) // no new certificates inserted.
+
 	{
 		// Flatten data structure.
 		_, span := w.Tracer.Start(ctx, "flatten")

--- a/pkg/mapserver/updater/manager.go
+++ b/pkg/mapserver/updater/manager.go
@@ -2,8 +2,6 @@ package updater
 
 import (
 	"context"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/netsec-ethz/fpki/pkg/cache"
@@ -22,7 +20,6 @@ const domainIdCacheSize = 10000
 // The requirement of using the same worker for a given certificate or domain prevents deadlocks
 // in the DBE.
 type Manager struct {
-	inserterConcurrency
 	Conn            db.Conn                         // DB
 	MultiInsertSize int                             // amount of entries before calling the DB
 	Stats           *Stats                          // Statistics about the update
@@ -57,13 +54,12 @@ func NewManager(
 
 	// Create the Manager structure.
 	m := &Manager{
-		inserterConcurrency: newInserterConcurrency(bundleSize, onBundleFunc),
-		Conn:                conn,
-		MultiInsertSize:     multiInsertSize,
-		Stats:               NewStatistics(statsUpdateFreq, statsUpdateFunc),
-		ShardFuncCert:       selectPartition,
-		ShardFuncDomain:     selectPartition,
-		IncomingCertChan:    make(chan Certificate),
+		Conn:             conn,
+		MultiInsertSize:  multiInsertSize,
+		Stats:            NewStatistics(statsUpdateFreq, statsUpdateFunc),
+		ShardFuncCert:    selectPartition,
+		ShardFuncDomain:  selectPartition,
+		IncomingCertChan: make(chan Certificate),
 		// IncomingCertPtrChan: make(chan *Certificate),
 	}
 
@@ -244,51 +240,4 @@ func (m *Manager) createPipeline(workerCount int) error {
 	)
 
 	return err
-}
-
-type inserterConcurrency struct {
-	BundleSize       uint64        // Number of certs when triggering a bundle call.
-	OnBundleFinished func()        // Function called when having a bundle.
-	CertsCounter     atomic.Uint64 // Updated by every inserter.
-	inserters        sync.WaitGroup
-	insertingMu      sync.Mutex
-}
-
-func newInserterConcurrency(bundleSize uint64, onBundleFinished func()) inserterConcurrency {
-	return inserterConcurrency{
-		BundleSize:       bundleSize,
-		OnBundleFinished: onBundleFinished,
-		inserters:        sync.WaitGroup{},
-		insertingMu:      sync.Mutex{},
-	}
-}
-
-// startInserting must be called by any routine modifying the DB.
-// It returns a function that must be run after the routine is done.
-// startInserting will run the OnBundleFunction if the count of inserter certs is enough.
-func (ins *inserterConcurrency) startInserting() (doneFunc func(newCertsInserted int)) {
-	// Serialize all calls via the common mutex.
-	ins.insertingMu.Lock()
-
-	// Add this inserter to the barrier.
-	ins.inserters.Add(1)
-
-	if ins.CertsCounter.Load() >= ins.BundleSize {
-		// Wait until all inserters are done.
-		ins.inserters.Done() // Discount this inserter.
-		ins.inserters.Wait()
-		ins.inserters.Add(1) // Add this inserter again.
-
-		// Run the bundle function.
-		ins.OnBundleFinished()
-
-		// Reset the counter.
-		ins.CertsCounter.Store(0)
-	}
-	ins.insertingMu.Unlock() // Go concurrent again.
-
-	return func(newCertsInserted int) {
-		ins.CertsCounter.Add(uint64(newCertsInserted))
-		ins.inserters.Done()
-	}
 }

--- a/pkg/mapserver/updater/manager_test.go
+++ b/pkg/mapserver/updater/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -121,7 +122,15 @@ func TestManagerStart(t *testing.T) {
 			conn := testdb.Connect(t, config)
 			defer conn.Close()
 
-			manager, err := NewManager(tc.NWorkers, conn, tc.MultiInsertSize, time.Second, nil)
+			manager, err := NewManager(
+				tc.NWorkers,
+				conn,
+				tc.MultiInsertSize,
+				math.MaxUint64,
+				nil,
+				time.Hour,
+				nil,
+			)
 			require.NoError(t, err)
 
 			certs := tc.certGenerator(t, mockLeaves(tc.NLeafDomains)...)
@@ -199,7 +208,9 @@ func TestManagerResume(t *testing.T) {
 				tc.NWorkers,
 				conn,
 				tc.MultiInsertSize,
-				time.Second,
+				math.MaxUint64,
+				nil,
+				time.Hour,
 				nil,
 			)
 			require.NoError(t, err)
@@ -413,7 +424,7 @@ func createManagerWithOutputFunction(
 	outType pip.DebugPurposesOnlyOutputType,
 ) *Manager {
 
-	manager, err := NewManager(workerCount, conn, 10, 1, nil)
+	manager, err := NewManager(workerCount, conn, 10, math.MaxUint64, nil, time.Hour, nil)
 	require.NoError(t, err)
 
 	stages := manager.Pipeline.Stages

--- a/pkg/mapserver/updater/updater.go
+++ b/pkg/mapserver/updater/updater.go
@@ -575,9 +575,11 @@ func UpdateSMT(ctx context.Context, conn db.Conn) error {
 	fmt.Printf("\nsmt [%s]: SMT updated\n", time.Now().Format(time.Stamp))
 
 	// Save root value:
-	err = conn.SaveRoot(ctx, (*common.SHA256Output)(smtTrie.Root))
-	if err != nil {
-		return err
+	if smtTrie.Root != nil {
+		err = conn.SaveRoot(ctx, (*common.SHA256Output)(smtTrie.Root))
+		if err != nil {
+			return err
+		}
 	}
 	fmt.Printf("smt [%s]: new root saved\n", time.Now().Format(time.Stamp))
 

--- a/pkg/mapserver/updater/workers_test.go
+++ b/pkg/mapserver/updater/workers_test.go
@@ -2,6 +2,7 @@ package updater
 
 import (
 	"context"
+	"math"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -31,7 +32,7 @@ func TestAllocsCertInserterProcessBundle(t *testing.T) {
 	conn := &noopdb.Conn{}
 
 	// Prepare the manager and worker for the test.
-	manager, err := NewManager(1, conn, 1000, 1, nil)
+	manager, err := NewManager(1, conn, 1000, math.MaxUint64, nil, time.Hour, nil)
 	require.NoError(t, err)
 
 	// Create mock certificates.
@@ -75,7 +76,7 @@ func TestCertInserterAllocationsOverhead(t *testing.T) {
 	// DB with no operations.
 	conn := &noopdb.Conn{}
 
-	manager, err := NewManager(1, conn, 10, 1, nil)
+	manager, err := NewManager(1, conn, 10, math.MaxUint64, nil, time.Hour, nil)
 	require.NoError(t, err)
 
 	// Create mock certificates.
@@ -148,7 +149,7 @@ func TestDomainBatcherNotBlocking(t *testing.T) {
 	t.Logf("# domains: %d", len(domains))
 
 	const batchSize = 2
-	manager, err := NewManager(1, conn, batchSize, 1, nil)
+	manager, err := NewManager(1, conn, batchSize, math.MaxUint64, nil, time.Hour, nil)
 	require.NoError(t, err)
 
 	// Create a domain batcher stage.
@@ -261,7 +262,7 @@ func TestDomainBatcherAllocationOverhead(t *testing.T) {
 	certs := toCertificates(random.BuildTestRandomCertTree(t, random.RandomLeafNames(t, N)...))
 	domains := extractDomains(certs)
 
-	manager, err := NewManager(1, conn, 10, 1, nil)
+	manager, err := NewManager(1, conn, 10, math.MaxUint64, nil, time.Hour, nil)
 	require.NoError(t, err)
 
 	// Create a domain batcher stage.
@@ -337,7 +338,7 @@ func TestAllocsDomainBatchWorkerProcessBundle(t *testing.T) {
 	certs := toCertificates(random.BuildTestRandomCertTree(t, random.RandomLeafNames(t, N)...))
 
 	// Prepare the manager and worker for the test.
-	manager, err := NewManager(1, conn, 1000, 1, nil)
+	manager, err := NewManager(1, conn, 1000, math.MaxUint64, nil, time.Hour, nil)
 	require.NoError(t, err)
 	worker := newDomainInserter(0, manager)
 	worker.Ctx = ctx
@@ -372,7 +373,7 @@ func TestDomainBatchWorkerAllocationsOverhead(t *testing.T) {
 	certs := toCertificates(random.BuildTestRandomCertTree(t, random.RandomLeafNames(t, N)...))
 	domains := extractDomains(certs)
 
-	manager, err := NewManager(1, conn, 10, 1, nil)
+	manager, err := NewManager(1, conn, 10, math.MaxUint64, nil, time.Hour, nil)
 	require.NoError(t, err)
 
 	// Create a cert worker stage. Input channel of Certificate, output of DirtyDomain.

--- a/pkg/pipeline/stall_resume.go
+++ b/pkg/pipeline/stall_resume.go
@@ -1,0 +1,208 @@
+package pipeline
+
+import (
+	"sync"
+
+	"github.com/netsec-ethz/fpki/pkg/util"
+)
+
+func WithAutoResumeAtStage(
+	targetStage int,
+	shouldResumeNow func() bool,
+	relink func(*Pipeline),
+	affectedStages ...int,
+) pipelineOptions {
+	return func(p *Pipeline) {
+		origLinkFunc := p.linkFunc
+		// Sort the affected stages so that Resume can walk backwards.
+		affectedStages := util.Qsort(affectedStages)
+
+		p.linkFunc = func(p *Pipeline) {
+			DebugPrintf("[autoresume] calling original link function\n")
+			origLinkFunc(p)
+
+			// Replace the target's error channel with a new one, but keep the original one open.
+			// Every time the target sends a message to its error channel, forward it to the
+			// original one (the one that the previous stage has linked).
+			// But when the target closes its error channel, if shouldResumeNow indicates so,
+			// create a new error channel and keep the same behavior as before.
+
+			// Tag the target stage.
+			target := p.Stages[targetStage]
+
+			// Replace the salient error channel of the target stage.
+			origErrCh := target.Base().ErrCh
+			DebugPrintf("[autoresume] orig error channel: %s\n", chanPtr(origErrCh))
+			newErrCh := make(chan error)
+			target.Base().ErrCh = newErrCh
+			DebugPrintf("[autoresume] new error channel: %s\n", chanPtr(newErrCh))
+
+			go func() {
+				for {
+					for err := range newErrCh {
+						DebugPrintf("[autoresume] err from target: %v\n", err)
+						// Pass it along.
+						origErrCh <- err
+					}
+					DebugPrintf("[autoresume] target error channel %s is closed\n",
+						chanPtr(newErrCh))
+
+					// The target closed the error channel, check whether to resume automatically.
+					if !shouldResumeNow() {
+						DebugPrintf("[autoresume] *************** closing sniffer error channel\n")
+						// The function indicates not to resume, close the new error channel.
+						close(origErrCh)
+						// And exit, as once not resuming means stopping.
+						return
+					}
+
+					DebugPrintf("[autoresume] request to resume: true. Affected stages: %v\n",
+						affectedStages)
+					// Auto resume was requested, prepare affected stages.
+					for i := len(affectedStages) - 1; i >= 0; i-- {
+						p.Stages[affectedStages[i]].Prepare(p.Ctx)
+					}
+
+					// The target stage needs a new error and stop channels.
+					newErrCh = make(chan error)
+					target.Base().ErrCh = newErrCh
+					target.Base().StopCh = make(chan None)
+
+					if sink, ok := target.(SinkLike); ok {
+						sink.PrepareSink(p.Ctx)
+					}
+					DebugPrintf("[autoresume] stages prepared\n")
+
+					relink(p)
+					DebugPrintf("[autoresume] relink called\n")
+
+					// Resume all affected and target stages.
+					for i := len(affectedStages) - 1; i >= 0; i-- {
+						p.Stages[affectedStages[i]].Resume(p.Ctx)
+					}
+					// Also the target stage.
+					target.Resume(p.Ctx)
+					DebugPrintf("[autoresume] stages resumed\n")
+				}
+			}()
+		}
+	}
+}
+
+// WithStallStages allows to temporarily stop (stall) stages, given a function that is evaluated at some
+// stages. The stages to stall can overlap the stages where the function is evaluated.
+// Finally, when the indicated stages are stalled, the whenStalled function is called.
+// There can be several concurrent calls to the shouldStallPipeline evaluation function,
+// but only one to whenStalled.
+func WithStallStages(
+	stallTheseStages []StageLike,
+	whenStalled func(),
+	shouldStallPipeline func(StageLike) bool,
+	evaluateAt []StageLike,
+) pipelineOptions {
+
+	// Mutex that all stages in evaluateAt and stallTheseStages need to acquire.
+	// If acquired by an evaluate stage, and the evaluation returns true, the mutex is only
+	// released after calling the whenStalled function.
+	stallMu := sync.Mutex{}
+
+	// Barrier for the stages in stallTheseStages when they are working. All stages must reach
+	// the barrier before the whenStalled function to be called.
+	workingStagesWg := sync.WaitGroup{}
+	// This mutex is necessary to avoid adding workers while waiting for them to finish.
+	workingStagesWgMu := sync.Mutex{}
+
+	// The option modifies the onBeforeData callback of the stages in evaluatedAt, and the
+	// onBeforeData and onProcessed callbacks of the stages in stallTheseStages.
+	return func(p *Pipeline) {
+		for _, s := range evaluateAt {
+			s := s
+
+			// Save the previous onBeforeData function.
+			prevOnBeforeData := s.Base().onBeforeData
+
+			s.Base().onBeforeData = func() {
+				// Call the previous onBeforeData.
+				prevOnBeforeData()
+
+				// Evaluate iff initially we are not stalling.
+				DebugPrintf("[%s] [stall] evaluating stall\n", s.Base().Name)
+				stallMu.Lock()
+				stall := shouldStallPipeline(s)
+				DebugPrintf("[%s] [stall] should we stall? %v\n", s.Base().Name, stall)
+
+				// Indicate to stall the pipeline if should stall and this is the first time.
+				if stall {
+					DebugPrintf("[%s] [stall] this stage will stall the pipeline\n", s.Base().Name)
+					// Run in separate goroutine, to avoid blocking this stage if it is also
+					// part of the stallTheseStages.
+					go func() {
+						// Wait for all to stall.
+						DebugPrintf("[%s] [stall-releaser] waiting to get the working group\n", s.Base().Name)
+						workingStagesWgMu.Lock()
+						defer workingStagesWgMu.Unlock()
+						DebugPrintf("[%s] [stall-releaser] waiting for stages to stall\n", s.Base().Name)
+						workingStagesWg.Wait()
+						DebugPrintf("[%s] [stall-releaser] all stages have stalled\n", s.Base().Name)
+
+						// Execute whenStalled()
+						whenStalled()
+
+						// Resume the stalled stages.
+						DebugPrintf("[%s] [stall-releaser] signaling stages to continue\n", s.Base().Name)
+						stallMu.Unlock()
+					}()
+				} else {
+					stallMu.Unlock()
+				}
+
+				DebugPrintf("[%s] [stall] out of evaluation\n", s.Base().Name)
+			}
+		}
+
+		for _, s := range stallTheseStages {
+			s := s
+
+			// Get the previous onBeforeData.
+			prevOnBeforeData := s.Base().onBeforeData
+
+			s.Base().onBeforeData = func() {
+				// Call the previous onBeforeData.
+				prevOnBeforeData()
+
+				// Acquire the mutex, will have to wait if stalling.
+				DebugPrintf("[%s] [stall] before mutex\n", s.Base().Name)
+				stallMu.Lock()
+				// Release it immediately, we have serialized the stages using the mutex.
+				defer func() {
+					stallMu.Unlock()
+					defer DebugPrintf("[%s] [stall] out of maybe stalling\n", s.Base().Name)
+				}()
+			}
+
+			prevOnReceivedData := s.Base().onReceivedData
+			s.Base().onReceivedData = func() {
+				// Call previous.
+				prevOnReceivedData()
+
+				// Indicate that this stage is about to start working.
+				DebugPrintf("[%s] [stall] worker waiting to get the group\n", s.Base().Name)
+				workingStagesWgMu.Lock()
+				defer workingStagesWgMu.Unlock()
+
+				DebugPrintf("[%s] [stall] adding an individual to the working group\n", s.Base().Name)
+				workingStagesWg.Add(1)
+			}
+
+			prevOnProcessed := s.Base().onProcessed
+			s.Base().onProcessed = func() {
+				// Call previous.
+				prevOnProcessed()
+
+				// Indicate that this stage has finished working.
+				DebugPrintf("[%s] [stall] removing one individual from the working group\n", s.Base().Name)
+				workingStagesWg.Done()
+			}
+		}
+	}
+}


### PR DESCRIPTION
Introduce support for bundles and solve issues.
For efficiency, the pipeline modifies the DB in different stage types, with multiple stage instances per type.
Since the SMT update is a synchronized step, where the atomic unit is a line (or chain) seen from the CSV files, the synchronization step and serialization needs to happen on a stage type that handles either lines or chains.
We pick the `chainToCerts` stage type for this.
Steps:

- [x] Support certificate bundles again.
    - [x] Add methods in DB handling or `Manager` that account for inserters finishing.
    - [x] Evaluate the current amount of inserted certificates in `chainToCerts`
    - [x] If a new bundle is to be created, stop the pipeline, wait until termination, then run `OnBundleFinished`
    - [x] Resume the pipeline if it was stopped.

(Done via the `WithStallStages` option in the pipeline)

Additionally and while reproducing bugs related to bundles and concurrent insertions, some deadlocks have been observed at `articuno`. Steps:
- [ ] Reproduce deadlocks in DB at articuno when the bundle size is small.
- [ ] Add retry mechanism to mitigate DB deadlocks.

Deadlocks are not reproducible anymore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/fpki/70)
<!-- Reviewable:end -->
