### PR TITLE
Journal Cleanup

### DIFF
--- a/cmd/ingest/cmdflags/flags.go
+++ b/cmd/ingest/cmdflags/flags.go
@@ -9,16 +9,19 @@ import (
 
 // Flags for the command line:
 var (
-	CpuProfile       *string
-	MemProfile       *string
-	MultiInsertSize  *int
-	NumFiles         *int
-	NumParsers       *int
-	NumChainToCerts  *int
-	NumDBWriters     *int
-	Strategy         *string
-	FileBatch        *int
-	JournalFile      *string
+	CpuProfile      *string
+	MemProfile      *string
+	MultiInsertSize *int
+	NumFiles        *int
+	NumParsers      *int
+	NumChainToCerts *int
+	NumDBWriters    *int
+	Strategy        *string
+	FileBatch       *int
+	JournalFile     *string
+	// IncludePlainCSVs restores the legacy behavior of also ingesting uncompressed
+	// bundle files alongside the default .gz input set.
+	IncludePlainCSVs *bool
 	SkipMissingFiles *bool
 )
 
@@ -59,6 +62,9 @@ func _configureFlags() {
 		"all files are processed in one batch")
 	JournalFile = flag.String("journal", DefJournalFile,
 		"Journal file to keep track of progress and resume")
+	IncludePlainCSVs = flag.Bool("includeplaincsvs", false,
+		"include plain .csv files in addition to .gz files when listing ingest inputs; "+
+			"by default only .gz files are processed")
 	SkipMissingFiles = flag.Bool("skipmissingfiles", false,
 		"report missing input files and continue instead of failing the batch")
 	flag.Parse()

--- a/cmd/ingest/diagnostics_test.go
+++ b/cmd/ingest/diagnostics_test.go
@@ -30,15 +30,16 @@ func TestCreateDiagnosticsBundleWritesExpectedFiles(t *testing.T) {
 	})
 
 	cfg := RunConfig{
-		Directory:       "/input",
-		Strategy:        "onlyingest",
-		JournalFile:     "/tmp/journal.json",
-		FileBatch:       200,
-		MultiInsertSize: 1000,
-		NumFiles:        16,
-		NumParsers:      8,
-		NumChainToCerts: 4,
-		NumDBWriters:    2,
+		Directory:        "/input",
+		Strategy:         "onlyingest",
+		JournalFile:      "/tmp/journal.json",
+		FileBatch:        200,
+		MultiInsertSize:  1000,
+		NumFiles:         16,
+		NumParsers:       8,
+		NumChainToCerts:  4,
+		NumDBWriters:     2,
+		IncludePlainCSVs: true,
 	}
 
 	var stderr bytes.Buffer
@@ -75,15 +76,16 @@ func TestCreateDiagnosticsBundleWritesMetadata(t *testing.T) {
 	})
 
 	cfg := RunConfig{
-		Directory:       "/input",
-		Strategy:        "onlyingest",
-		JournalFile:     "/tmp/journal.json",
-		FileBatch:       200,
-		MultiInsertSize: 1000,
-		NumFiles:        16,
-		NumParsers:      8,
-		NumChainToCerts: 4,
-		NumDBWriters:    2,
+		Directory:        "/input",
+		Strategy:         "onlyingest",
+		JournalFile:      "/tmp/journal.json",
+		FileBatch:        200,
+		MultiInsertSize:  1000,
+		NumFiles:         16,
+		NumParsers:       8,
+		NumChainToCerts:  4,
+		NumDBWriters:     2,
+		IncludePlainCSVs: true,
 	}
 
 	var stderr bytes.Buffer
@@ -105,6 +107,7 @@ func TestCreateDiagnosticsBundleWritesMetadata(t *testing.T) {
 	require.Contains(t, text, "numparsers=8")
 	require.Contains(t, text, "numdechainers=4")
 	require.Contains(t, text, "numdbworkers=2")
+	require.Contains(t, text, "includeplaincsvs=true")
 	require.Contains(t, text, "directory=/input")
 	require.Contains(t, text, "journal=/tmp/journal.json")
 	require.Contains(t, text, `args=[`)

--- a/cmd/ingest/journal/journal.go
+++ b/cmd/ingest/journal/journal.go
@@ -7,13 +7,17 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
+	"strconv"
 	"sync"
 	"time"
 
 	"github.com/netsec-ethz/fpki/pkg/util"
 )
 
+// Journal persists ingest progress so future runs can skip files whose
+// certificate-index ranges are already fully covered.
 type Journal struct {
 	mu          sync.Mutex
 	closed      bool
@@ -24,9 +28,11 @@ type Journal struct {
 	// persisted job history may contain entries from earlier invocations.
 	CurrentJob     Job `json:"-"`
 	Jobs           []Job
-	CompletedFiles map[string]map[string]struct{}
+	CompletedFiles map[string][]Interval
 }
 
+// JobConfiguration captures the ingest-mode settings that affect how one run
+// should be executed and resumed.
 type JobConfiguration struct {
 	IngestFiles bool
 	Coalesce    bool
@@ -37,11 +43,20 @@ type JobConfiguration struct {
 	IncludePlainCSVs bool
 }
 
+// Job records one invocation of the ingest command in the journal history.
 type Job struct {
 	Cwd              string           `json:"Cwd"`
 	Cmd              []string         `json:"Cmd"`
 	JobConfiguration JobConfiguration `json:"JobConfiguration"`
 }
+
+// Interval represents an inclusive range of certificate indices.
+type Interval struct {
+	Start uint
+	End   uint
+}
+
+var completedIntervalPattern = regexp.MustCompile(`^(\d+)-(\d+)$`)
 
 // NewJobConfiguration translates the ingest strategy flags into the journal's
 // execution configuration, including whether plain `.csv` bundles should be
@@ -74,7 +89,7 @@ func NewJournal(journalFile string, cfg JobConfiguration, ingestDir string) (*Jo
 	j := &Journal{
 		JournalFile:    journalFile,
 		IngestDir:      ingestDir,
-		CompletedFiles: map[string]map[string]struct{}{},
+		CompletedFiles: map[string][]Interval{},
 	}
 
 	// Check if file exists.
@@ -107,9 +122,9 @@ func NewJournal(journalFile string, cfg JobConfiguration, ingestDir string) (*Jo
 	return j, nil
 }
 
-// AddCompletedFiles adds the file names to the set of completed files.
-// The function normalizes them into ingest-dir and filename keys and inserts
-// them into the nested completed-files set.
+// AddCompletedFiles adds the file names to the set of completed intervals.
+// The function normalizes them into ingest-dir and interval keys and merges
+// them into the nested completed-interval slices.
 func (j *Journal) AddCompletedFiles(files []string) error {
 	j.mu.Lock()
 	defer j.mu.Unlock()
@@ -119,18 +134,19 @@ func (j *Journal) AddCompletedFiles(files []string) error {
 	}
 
 	for _, file := range files {
-		ingestDirBase, fileBase, err := normalizeCompletedFile(file, j.IngestDir)
+		ingestDirBase, interval, err := normalizeCompletedFile(file, j.IngestDir)
 		if err != nil {
 			return err
 		}
-		addCompletedFile(j.CompletedFiles, ingestDirBase, fileBase)
+		addCompletedInterval(j.CompletedFiles, ingestDirBase, interval)
 	}
 	return j.writeLocked()
 }
 
 // PendingFiles returns the set subtraction LiveDirectoryListing - CompletedFiles.
-// CompletedFiles is expected to already contain only normalized ingest-dir and
-// filename keys, so live files are normalized on the fly before membership is checked.
+// CompletedFiles is expected to already contain normalized ingest-dir and
+// interval coverage, so live files are normalized on the fly before coverage
+// is checked.
 func (j *Journal) PendingFiles() ([]string, error) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
@@ -146,11 +162,11 @@ func (j *Journal) PendingFiles() ([]string, error) {
 
 	pending := make([]string, 0, len(files))
 	for _, file := range files {
-		ingestDirBase, fileBase, err := normalizeCompletedFile(file, j.IngestDir)
+		ingestDirBase, interval, err := normalizeCompletedFile(file, j.IngestDir)
 		if err != nil {
 			return nil, err
 		}
-		if containsCompletedFile(j.CompletedFiles, ingestDirBase, fileBase) {
+		if containsCompletedInterval(j.CompletedFiles, ingestDirBase, interval) {
 			continue
 		}
 		pending = append(pending, file)
@@ -270,6 +286,7 @@ func (j *Journal) write(f *os.File) error {
 	return nil
 }
 
+// writeLocked atomically rewrites the journal file while the journal mutex is held.
 func (j *Journal) writeLocked() error {
 	dir := filepath.Dir(j.JournalFile)
 	tempFile, err := os.CreateTemp(dir, filepath.Base(j.JournalFile)+".tmp-*")
@@ -306,6 +323,7 @@ func (j *Journal) writeLocked() error {
 	return nil
 }
 
+// registerShutdownHook ensures the journal is flushed during global process shutdown.
 func (j *Journal) registerShutdownHook() {
 	j.closeOnce.Do(func() {
 		util.RegisterShutdownFunc(j.Close)
@@ -313,26 +331,30 @@ func (j *Journal) registerShutdownHook() {
 }
 
 // normalize restores the CompletedFiles invariant after loading JSON:
-// every entry must be stored as CompletedFiles[ingestDirBase][fileBase].
+// every entry must be stored as CompletedFiles[ingestDirBase] as a sorted,
+// non-overlapping, minimal interval list.
 func (j *Journal) normalize() error {
 	if j.CompletedFiles == nil {
-		j.CompletedFiles = map[string]map[string]struct{}{}
+		j.CompletedFiles = map[string][]Interval{}
 		return nil
 	}
 
-	for ingestDirBase, files := range j.CompletedFiles {
+	for ingestDirBase, intervals := range j.CompletedFiles {
 		if ingestDirBase == "" {
 			return fmt.Errorf("empty ingest directory key in completed files")
 		}
-		if files == nil {
-			j.CompletedFiles[ingestDirBase] = map[string]struct{}{}
+		if intervals == nil {
+			j.CompletedFiles[ingestDirBase] = []Interval{}
 			continue
 		}
-		for fileBase := range files {
-			if fileBase == "" {
-				return fmt.Errorf("empty file key in completed files for ingest dir %q", ingestDirBase)
+		normalized := make([]Interval, 0, len(intervals))
+		for _, interval := range intervals {
+			if interval.Start > interval.End {
+				return fmt.Errorf("invalid interval %s for ingest dir %q", interval.String(), ingestDirBase)
 			}
+			normalized = appendInterval(normalized, interval)
 		}
+		j.CompletedFiles[ingestDirBase] = normalized
 	}
 
 	return nil
@@ -344,13 +366,20 @@ func (j *Journal) read(f *os.File) error {
 	if err != nil {
 		return fmt.Errorf("cannot read journal file: %w", err)
 	}
-	var raw Journal
+	var raw struct {
+		Jobs           []Job           `json:"Jobs"`
+		CompletedFiles json.RawMessage `json:"CompletedFiles"`
+	}
 	err = json.Unmarshal(buff, &raw)
 	if err != nil {
 		return fmt.Errorf("journal file wrong format: %w", err)
 	}
-	j.CompletedFiles = raw.CompletedFiles
 	j.Jobs = raw.Jobs
+	completedFiles, err := decodeCompletedFiles(raw.CompletedFiles)
+	if err != nil {
+		return fmt.Errorf("journal file wrong format: %w", err)
+	}
+	j.CompletedFiles = completedFiles
 	if err := j.normalize(); err != nil {
 		return fmt.Errorf("journal file wrong format: %w", err)
 	}
@@ -365,35 +394,211 @@ func (j *Journal) readAndClose(f *os.File) error {
 	return closeFile(f)
 }
 
-// addCompletedFile inserts a completed file into the nested set, creating the
-// ingest-dir bucket when needed.
-func addCompletedFile(completed map[string]map[string]struct{}, ingestDirBase, fileBase string) {
-	files, ok := completed[ingestDirBase]
-	if !ok {
-		files = map[string]struct{}{}
-		completed[ingestDirBase] = files
+// decodeCompletedFiles accepts both the current interval-array encoding and the
+// legacy filename-set encoding, returning normalized interval coverage.
+func decodeCompletedFiles(raw json.RawMessage) (map[string][]Interval, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return map[string][]Interval{}, nil
 	}
-	files[fileBase] = struct{}{}
+
+	var newFormat map[string][]string
+	if err := json.Unmarshal(raw, &newFormat); err == nil {
+		completed := make(map[string][]Interval, len(newFormat))
+		for ingestDirBase, encodedIntervals := range newFormat {
+			intervals := make([]Interval, 0, len(encodedIntervals))
+			for _, encoded := range encodedIntervals {
+				interval, err := parseIntervalString(encoded)
+				if err != nil {
+					return nil, err
+				}
+				intervals = append(intervals, interval)
+			}
+			completed[ingestDirBase] = intervals
+		}
+		return completed, nil
+	}
+
+	var legacyFormat map[string]map[string]struct{}
+	if err := json.Unmarshal(raw, &legacyFormat); err == nil {
+		completed := make(map[string][]Interval, len(legacyFormat))
+		for ingestDirBase, files := range legacyFormat {
+			for fileBase := range files {
+				interval, err := parseFileInterval(fileBase)
+				if err != nil {
+					return nil, err
+				}
+				addCompletedInterval(completed, ingestDirBase, interval)
+			}
+		}
+		return completed, nil
+	}
+
+	return nil, fmt.Errorf("unsupported completed files encoding")
 }
 
-// containsCompletedFile reports whether the nested completed-files set already
-// contains the given ingest-dir and filename pair.
-func containsCompletedFile(completed map[string]map[string]struct{}, ingestDirBase, fileBase string) bool {
-	files, ok := completed[ingestDirBase]
+// journalOnDisk is the persisted JSON shape for journal state.
+type journalOnDisk struct {
+	Jobs           []Job               `json:"Jobs"`
+	CompletedFiles map[string][]string `json:"CompletedFiles"`
+}
+
+// MarshalJSON serializes the in-memory interval representation into the
+// human-readable on-disk string-array format.
+func (j *Journal) MarshalJSON() ([]byte, error) {
+	onDisk := journalOnDisk{
+		Jobs:           j.Jobs,
+		CompletedFiles: make(map[string][]string, len(j.CompletedFiles)),
+	}
+	for ingestDirBase, intervals := range j.CompletedFiles {
+		encoded := make([]string, len(intervals))
+		for i, interval := range intervals {
+			encoded[i] = interval.String()
+		}
+		onDisk.CompletedFiles[ingestDirBase] = encoded
+	}
+	return json.Marshal(onDisk)
+}
+
+// addCompletedInterval inserts a completed interval into the nested set,
+// creating the ingest-dir bucket when needed.
+func addCompletedInterval(completed map[string][]Interval, ingestDirBase string, interval Interval) {
+	intervals, ok := completed[ingestDirBase]
+	if !ok {
+		intervals = []Interval{}
+	}
+	completed[ingestDirBase] = appendInterval(intervals, interval)
+}
+
+// appendInterval inserts one interval into an existing sorted interval list,
+// merging overlaps and adjacencies to preserve a minimal canonical form.
+func appendInterval(intervals []Interval, interval Interval) []Interval {
+	// Find the insertion point by interval start. Because the slice is kept
+	// sorted, only the interval immediately before the insertion point and any
+	// intervals starting at or after it can possibly merge with the new range.
+	idx, _ := slices.BinarySearchFunc(intervals, interval, func(existing, target Interval) int {
+		switch {
+		case existing.Start < target.Start:
+			return -1
+		case existing.Start > target.Start:
+			return 1
+		default:
+			return 0
+		}
+	})
+
+	// First absorb a predecessor if it overlaps with or directly touches the
+	// new interval. This may shift the insertion point left by one slot.
+	if idx > 0 && canMerge(intervals[idx-1], interval) {
+		idx--
+		interval = mergeIntervals(intervals[idx], interval)
+		intervals = append(intervals[:idx], intervals[idx+1:]...)
+	}
+	// Then keep consuming following intervals for as long as the merged range
+	// still overlaps or touches them, yielding one minimal interval in the end.
+	for idx < len(intervals) && canMerge(interval, intervals[idx]) {
+		interval = mergeIntervals(interval, intervals[idx])
+		intervals = append(intervals[:idx], intervals[idx+1:]...)
+	}
+
+	// Reinsert the final merged interval at the computed position while
+	// preserving sort order.
+	intervals = append(intervals, Interval{})
+	copy(intervals[idx+1:], intervals[idx:])
+	intervals[idx] = interval
+	return intervals
+}
+
+// canMerge reports whether two inclusive intervals overlap or touch.
+func canMerge(a, b Interval) bool {
+	return a.Start <= b.End+1 && b.Start <= a.End+1
+}
+
+// mergeIntervals returns the smallest interval covering both inputs.
+func mergeIntervals(a, b Interval) Interval {
+	return Interval{
+		Start: min(a.Start, b.Start),
+		End:   max(a.End, b.End),
+	}
+}
+
+// containsCompletedInterval reports whether the nested completed interval set
+// fully covers the given ingest-dir and interval pair.
+func containsCompletedInterval(completed map[string][]Interval, ingestDirBase string, interval Interval) bool {
+	intervals, ok := completed[ingestDirBase]
 	if !ok {
 		return false
 	}
-	_, ok = files[fileBase]
-	return ok
+	idx, found := slices.BinarySearchFunc(intervals, interval, func(existing, target Interval) int {
+		switch {
+		case existing.Start < target.Start:
+			return -1
+		case existing.Start > target.Start:
+			return 1
+		default:
+			return 0
+		}
+	})
+	if found {
+		return intervals[idx].End >= interval.End
+	}
+	if idx == 0 {
+		return false
+	}
+	candidate := intervals[idx-1]
+	return candidate.Start <= interval.Start && candidate.End >= interval.End
 }
 
 // normalizeCompletedFile converts a current-run file path into the canonical
-// ingest-dir and filename pair.
-func normalizeCompletedFile(file string, ingestDir string) (string, string, error) {
+// ingest-dir and interval pair.
+func normalizeCompletedFile(file string, ingestDir string) (string, Interval, error) {
 	if ingestDir == "" {
-		return "", "", fmt.Errorf("cannot normalize completed file %q without ingest directory", file)
+		return "", Interval{}, fmt.Errorf("cannot normalize completed file %q without ingest directory", file)
 	}
-	return filepath.Base(filepath.Clean(ingestDir)), filepath.Base(file), nil
+	interval, err := parseFileInterval(file)
+	if err != nil {
+		return "", Interval{}, err
+	}
+	return filepath.Base(filepath.Clean(ingestDir)), interval, nil
+}
+
+// parseFileInterval extracts an inclusive interval from a bundle filename such
+// as `A-B.gz` or `A-B.csv`.
+func parseFileInterval(file string) (Interval, error) {
+	filename := filepath.Base(file)
+	if ext := filepath.Ext(filename); ext == ".gz" || ext == ".csv" {
+		filename = filename[:len(filename)-len(ext)]
+	}
+	interval, err := parseIntervalString(filename)
+	if err != nil {
+		return Interval{}, fmt.Errorf("cannot parse completed file %q: %w", file, err)
+	}
+	return interval, nil
+}
+
+// parseIntervalString parses the persisted `A-B` interval encoding.
+func parseIntervalString(value string) (Interval, error) {
+	groups := completedIntervalPattern.FindStringSubmatch(value)
+	if len(groups) != 3 {
+		return Interval{}, fmt.Errorf("unexpected interval %q", value)
+	}
+	start, err := strconv.ParseUint(groups[1], 10, 64)
+	if err != nil {
+		return Interval{}, fmt.Errorf("unexpected interval %q", value)
+	}
+	end, err := strconv.ParseUint(groups[2], 10, 64)
+	if err != nil {
+		return Interval{}, fmt.Errorf("unexpected interval %q", value)
+	}
+	interval := Interval{Start: uint(start), End: uint(end)}
+	if interval.Start > interval.End {
+		return Interval{}, fmt.Errorf("unexpected interval %q", value)
+	}
+	return interval, nil
+}
+
+// String formats the interval using the persisted inclusive `A-B` form.
+func (i Interval) String() string {
+	return fmt.Sprintf("%d-%d", i.Start, i.End)
 }
 
 // syncDirAfterRename is a NOOP (read comment inside the function).

--- a/cmd/ingest/journal/journal.go
+++ b/cmd/ingest/journal/journal.go
@@ -19,13 +19,12 @@ import (
 // Journal persists ingest progress so future runs can skip files whose
 // certificate-index ranges are already fully covered.
 type Journal struct {
-	mu                   sync.Mutex
-	closed               bool
-	closeOnce            sync.Once
-	JournalFile          string `json:"-"` // Exclude from JSON.
-	IngestDir            string `json:"-"` // Only used to refresh file listings.
-	loadedCompletedFiles map[string][]Interval
-	Jobs                 []Job
+	mu          sync.Mutex
+	closed      bool
+	closeOnce   sync.Once
+	JournalFile string `json:"-"` // Exclude from JSON.
+	IngestDir   string `json:"-"` // Only used to refresh file listings.
+	Jobs        []Job
 }
 
 // JobConfiguration captures the ingest-mode settings that affect how one run
@@ -42,15 +41,17 @@ type JobConfiguration struct {
 
 // Job records one invocation of the ingest command in the journal history.
 type Job struct {
-	Cwd              string                 `json:"Cwd"`
-	Cmd              []string               `json:"Cmd"`
-	JobConfiguration JobConfiguration       `json:"JobConfiguration"`
-	StartTime        string                 `json:"StartTime"`
-	EndTime          string                 `json:"EndTime"`
-	Coalesced        bool                   `json:"Coalesced"`
-	UpdatedSMT       bool                   `json:"UpdatedSMT"`
-	CompletedIndices map[string][]Interval  `json:"-"`
+	Cwd              string           `json:"Cwd"`
+	Cmd              []string         `json:"Cmd"`
+	JobConfiguration JobConfiguration `json:"JobConfiguration"`
+	StartTime        string           `json:"StartTime"`
+	EndTime          string           `json:"EndTime"`
+	Coalesced        bool             `json:"Coalesced"`
+	UpdatedSMT       bool             `json:"UpdatedSMT"`
+	CompletedIndices CompletedIndices `json:"CompletedIndices"`
 }
+
+type CompletedIndices map[string][]Interval
 
 // Interval represents an inclusive range of certificate indices.
 type Interval struct {
@@ -58,35 +59,8 @@ type Interval struct {
 	End   uint
 }
 
-var completedIntervalPattern = regexp.MustCompile(`^(\d+)-(\d+)$`)
-
-// NewJobConfiguration translates the ingest strategy flags into the journal's
-// execution configuration, including whether plain `.csv` bundles should be
-// considered alongside compressed `.gz` files.
-func NewJobConfiguration(strategy string, fileBatch int, includePlainCSVs bool) (JobConfiguration, error) {
-	jc := JobConfiguration{
-		FileBatch:        fileBatch,
-		IncludePlainCSVs: includePlainCSVs,
-	}
-	switch strategy {
-	case "onlyingest":
-		jc.IngestFiles = true
-	case "":
-		jc.IngestFiles = true
-		fallthrough
-	case "skipingest":
-		jc.Coalesce = true
-		fallthrough
-	case "onlysmtupdate":
-		jc.UpdateSMT = true
-	default:
-		return JobConfiguration{}, fmt.Errorf("strategy value not understood by journal: %s", strategy)
-	}
-	return jc, nil
-}
-
 // NewJournal loads or creates the journal file and normalizes any stored
-// completed-file entries into the journal key format.
+// completed-index entries into the journal key format.
 func NewJournal(journalFile string, cfg JobConfiguration, ingestDir string) (*Journal, error) {
 	j := &Journal{
 		JournalFile: journalFile,
@@ -121,6 +95,33 @@ func NewJournal(journalFile string, cfg JobConfiguration, ingestDir string) (*Jo
 	j.registerShutdownHook()
 	return j, nil
 }
+
+// NewJobConfiguration translates the ingest strategy flags into the journal's
+// execution configuration, including whether plain `.csv` bundles should be
+// considered alongside compressed `.gz` files.
+func NewJobConfiguration(strategy string, fileBatch int, includePlainCSVs bool) (JobConfiguration, error) {
+	jc := JobConfiguration{
+		FileBatch:        fileBatch,
+		IncludePlainCSVs: includePlainCSVs,
+	}
+	switch strategy {
+	case "onlyingest":
+		jc.IngestFiles = true
+	case "":
+		jc.IngestFiles = true
+		fallthrough
+	case "skipingest":
+		jc.Coalesce = true
+		fallthrough
+	case "onlysmtupdate":
+		jc.UpdateSMT = true
+	default:
+		return JobConfiguration{}, fmt.Errorf("strategy value not understood by journal: %s", strategy)
+	}
+	return jc, nil
+}
+
+var completedIntervalRe = regexp.MustCompile(`^(\d+)-(\d+)$`)
 
 // CommitProgress updates the active job's completed-index snapshot, optional
 // phase flags, and end timestamp in one persisted journal write.
@@ -279,15 +280,6 @@ func (j *Journal) Close() error {
 	return nil
 }
 
-// closeFile closes the file and wraps any filesystem error.
-func closeFile(f *os.File) error {
-	err := f.Close()
-	if err != nil {
-		return fmt.Errorf("cannot close journal file: %w", err)
-	}
-	return nil
-}
-
 // write encodes the journal to JSON and writes it to the provided file.
 func (j *Journal) write(f *os.File) error {
 	buf, err := json.MarshalIndent(j, "", "  ")
@@ -360,12 +352,6 @@ func (j *Journal) normalize() error {
 		}
 		j.Jobs[i].CompletedIndices = normalized
 	}
-
-	normalizedLoaded, err := normalizeCompletedIndices(j.loadedCompletedFiles)
-	if err != nil {
-		return err
-	}
-	j.loadedCompletedFiles = normalizedLoaded
 	return nil
 }
 
@@ -375,21 +361,12 @@ func (j *Journal) read(f *os.File) error {
 	if err != nil {
 		return fmt.Errorf("cannot read journal file: %w", err)
 	}
-	var raw rawJournal
-	err = json.Unmarshal(buff, &raw)
+	var decoded Journal
+	err = json.Unmarshal(buff, &decoded)
 	if err != nil {
 		return fmt.Errorf("journal file wrong format: %w", err)
 	}
-	jobs, err := decodeJobs(raw)
-	if err != nil {
-		return fmt.Errorf("journal file wrong format: %w", err)
-	}
-	j.Jobs = jobs
-	completedFiles, err := decodeCompletedIndices(raw.CompletedFiles)
-	if err != nil {
-		return fmt.Errorf("journal file wrong format: %w", err)
-	}
-	j.loadedCompletedFiles = completedFiles
+	j.Jobs = decoded.Jobs
 	if err := j.normalize(); err != nil {
 		return fmt.Errorf("journal file wrong format: %w", err)
 	}
@@ -404,142 +381,52 @@ func (j *Journal) readAndClose(f *os.File) error {
 	return closeFile(f)
 }
 
-// decodeCompletedIndices decodes the current interval-array encoding used on disk.
-func decodeCompletedIndices(raw json.RawMessage) (map[string][]Interval, error) {
-	if len(raw) == 0 || string(raw) == "null" {
-		return map[string][]Interval{}, nil
+func (j *Journal) latestCompletedIndices() CompletedIndices {
+	if len(j.Jobs) == 0 {
+		return CompletedIndices{}
 	}
-
-	var newFormat map[string][]string
-	if err := json.Unmarshal(raw, &newFormat); err == nil {
-		completed := make(map[string][]Interval, len(newFormat))
-		for ingestDirBase, encodedIntervals := range newFormat {
-			intervals := make([]Interval, 0, len(encodedIntervals))
-			for _, encoded := range encodedIntervals {
-				interval, err := parseIntervalString(encoded)
-				if err != nil {
-					return nil, err
-				}
-				intervals = append(intervals, interval)
-			}
-			completed[ingestDirBase] = intervals
-		}
-		return completed, nil
-	}
-
-	return nil, fmt.Errorf("unsupported completed indices encoding")
+	return j.Jobs[len(j.Jobs)-1].CompletedIndices
 }
 
-// journalOnDisk is the persisted JSON shape for journal state.
-type journalOnDisk struct {
-	Jobs []jobOnDisk `json:"Jobs"`
+func (j *Journal) currentJob() (*Job, error) {
+	if len(j.Jobs) == 0 {
+		return nil, fmt.Errorf("journal has no jobs")
+	}
+	job := &j.Jobs[len(j.Jobs)-1]
+	if job.CompletedIndices == nil {
+		job.CompletedIndices = CompletedIndices{}
+	}
+	return job, nil
 }
 
 // MarshalJSON serializes the in-memory interval representation into the
 // human-readable on-disk string-array format.
-func (j *Journal) MarshalJSON() ([]byte, error) {
-	onDisk := journalOnDisk{
-		Jobs: make([]jobOnDisk, 0, len(j.Jobs)),
-	}
-	for _, job := range j.Jobs {
-		onDisk.Jobs = append(onDisk.Jobs, encodeJob(job))
-	}
-	return json.Marshal(onDisk)
+func (c CompletedIndices) MarshalJSON() ([]byte, error) {
+	return json.Marshal(encodeCompletedIndices(c))
 }
 
-type rawJournal struct {
-	Jobs             []rawJob          `json:"Jobs"`
-	CompletedFiles   json.RawMessage   `json:"CompletedFiles"`
-	Cwds             []string          `json:"Cwds"`
-	Cmds             [][]string        `json:"Cmds"`
-	JobConfiguration *JobConfiguration `json:"JobConfiguration"`
-}
-
-type rawJob struct {
-	Cwd              string           `json:"Cwd"`
-	Cmd              []string         `json:"Cmd"`
-	JobConfiguration JobConfiguration `json:"JobConfiguration"`
-	StartTime        string           `json:"StartTime"`
-	EndTime          string           `json:"EndTime"`
-	Coalesced        bool             `json:"Coalesced"`
-	UpdatedSMT       bool             `json:"UpdatedSMT"`
-	CompletedIndices json.RawMessage  `json:"CompletedIndices"`
-}
-
-type jobOnDisk struct {
-	Cwd              string              `json:"Cwd"`
-	Cmd              []string            `json:"Cmd"`
-	JobConfiguration JobConfiguration    `json:"JobConfiguration"`
-	StartTime        string              `json:"StartTime"`
-	EndTime          string              `json:"EndTime"`
-	Coalesced        bool                `json:"Coalesced"`
-	UpdatedSMT       bool                `json:"UpdatedSMT"`
-	CompletedIndices map[string][]string `json:"CompletedIndices"`
-}
-
-func decodeJobs(raw rawJournal) ([]Job, error) {
-	if len(raw.Jobs) > 0 {
-		jobs := make([]Job, 0, len(raw.Jobs))
-		for _, rawJob := range raw.Jobs {
-			completedIndices, err := decodeCompletedIndices(rawJob.CompletedIndices)
-			if err != nil {
-				return nil, err
-			}
-			jobs = append(jobs, Job{
-				Cwd:              rawJob.Cwd,
-				Cmd:              slices.Clone(rawJob.Cmd),
-				JobConfiguration: rawJob.JobConfiguration,
-				StartTime:        rawJob.StartTime,
-				EndTime:          rawJob.EndTime,
-				Coalesced:        rawJob.Coalesced,
-				UpdatedSMT:       rawJob.UpdatedSMT,
-				CompletedIndices: completedIndices,
-			})
-		}
-		return jobs, nil
+// UnmarshalJSON restores the persisted string interval representation into the
+// in-memory interval representation used by journal logic.
+func (c *CompletedIndices) UnmarshalJSON(data []byte) error {
+	var raw map[string][]string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
 	}
 
-	count := max(len(raw.Cwds), len(raw.Cmds))
-	if raw.JobConfiguration != nil && count == 0 {
-		count = 1
+	completedIndices, err := decodeCompletedIndices(raw)
+	if err != nil {
+		return err
 	}
-	if count == 0 {
-		return nil, nil
-	}
-
-	jobs := make([]Job, 0, count)
-	for i := 0; i < count; i++ {
-		job := Job{
-			CompletedIndices: map[string][]Interval{},
-		}
-		if i < len(raw.Cwds) {
-			job.Cwd = raw.Cwds[i]
-		}
-		if i < len(raw.Cmds) {
-			job.Cmd = slices.Clone(raw.Cmds[i])
-		}
-		if raw.JobConfiguration != nil {
-			job.JobConfiguration = *raw.JobConfiguration
-		}
-		jobs = append(jobs, job)
-	}
-	return jobs, nil
+	*c = completedIndices
+	return nil
 }
 
-func encodeJob(job Job) jobOnDisk {
-	return jobOnDisk{
-		Cwd:              job.Cwd,
-		Cmd:              slices.Clone(job.Cmd),
-		JobConfiguration: job.JobConfiguration,
-		StartTime:        job.StartTime,
-		EndTime:          job.EndTime,
-		Coalesced:        job.Coalesced,
-		UpdatedSMT:       job.UpdatedSMT,
-		CompletedIndices: encodeCompletedIndices(job.CompletedIndices),
-	}
+// String formats the interval using the persisted inclusive `A-B` form.
+func (i Interval) String() string {
+	return fmt.Sprintf("%d-%d", i.Start, i.End)
 }
 
-func encodeCompletedIndices(completedIndices map[string][]Interval) map[string][]string {
+func encodeCompletedIndices(completedIndices CompletedIndices) map[string][]string {
 	encodedCompletedIndices := make(map[string][]string, len(completedIndices))
 	for ingestDirBase, intervals := range completedIndices {
 		encoded := make([]string, len(intervals))
@@ -551,12 +438,32 @@ func encodeCompletedIndices(completedIndices map[string][]Interval) map[string][
 	return encodedCompletedIndices
 }
 
-func normalizeCompletedIndices(completedIndices map[string][]Interval) (map[string][]Interval, error) {
-	if completedIndices == nil {
-		return map[string][]Interval{}, nil
+func decodeCompletedIndices(raw map[string][]string) (CompletedIndices, error) {
+	if raw == nil {
+		return CompletedIndices{}, nil
 	}
 
-	normalizedCompletedIndices := make(map[string][]Interval, len(completedIndices))
+	completed := make(CompletedIndices, len(raw))
+	for ingestDirBase, encodedIntervals := range raw {
+		intervals := make([]Interval, 0, len(encodedIntervals))
+		for _, encoded := range encodedIntervals {
+			interval, err := parseIntervalString(encoded)
+			if err != nil {
+				return nil, err
+			}
+			intervals = append(intervals, interval)
+		}
+		completed[ingestDirBase] = intervals
+	}
+	return completed, nil
+}
+
+func normalizeCompletedIndices(completedIndices CompletedIndices) (CompletedIndices, error) {
+	if completedIndices == nil {
+		return CompletedIndices{}, nil
+	}
+
+	normalizedCompletedIndices := make(CompletedIndices, len(completedIndices))
 	for ingestDirBase, intervals := range completedIndices {
 		if ingestDirBase == "" {
 			return nil, fmt.Errorf("empty ingest directory key in completed indices")
@@ -578,43 +485,26 @@ func normalizeCompletedIndices(completedIndices map[string][]Interval) (map[stri
 	return normalizedCompletedIndices, nil
 }
 
-func cloneCompletedIndices(completedIndices map[string][]Interval) map[string][]Interval {
-	cloned := make(map[string][]Interval, len(completedIndices))
+func cloneCompletedIndices(completedIndices CompletedIndices) CompletedIndices {
+	cloned := make(CompletedIndices, len(completedIndices))
 	for ingestDirBase, intervals := range completedIndices {
 		cloned[ingestDirBase] = slices.Clone(intervals)
 	}
 	return cloned
 }
 
-func (j *Journal) latestCompletedIndices() map[string][]Interval {
-	if len(j.Jobs) == 0 {
-		return j.loadedCompletedFiles
+// closeFile closes the file and wraps any filesystem error.
+func closeFile(f *os.File) error {
+	err := f.Close()
+	if err != nil {
+		return fmt.Errorf("cannot close journal file: %w", err)
 	}
-
-	completedIndices := j.Jobs[len(j.Jobs)-1].CompletedIndices
-	if len(completedIndices) > 0 {
-		return completedIndices
-	}
-	if len(j.loadedCompletedFiles) > 0 {
-		return j.loadedCompletedFiles
-	}
-	return completedIndices
-}
-
-func (j *Journal) currentJob() (*Job, error) {
-	if len(j.Jobs) == 0 {
-		return nil, fmt.Errorf("journal has no jobs")
-	}
-	job := &j.Jobs[len(j.Jobs)-1]
-	if job.CompletedIndices == nil {
-		job.CompletedIndices = map[string][]Interval{}
-	}
-	return job, nil
+	return nil
 }
 
 // addCompletedInterval inserts a completed interval into the nested set,
 // creating the ingest-dir bucket when needed.
-func addCompletedInterval(completed map[string][]Interval, ingestDirBase string, interval Interval) {
+func addCompletedInterval(completed CompletedIndices, ingestDirBase string, interval Interval) {
 	intervals, ok := completed[ingestDirBase]
 	if !ok {
 		intervals = []Interval{}
@@ -676,7 +566,7 @@ func mergeIntervals(a, b Interval) Interval {
 
 // containsCompletedInterval reports whether the nested completed interval set
 // fully covers the given ingest-dir and interval pair.
-func containsCompletedInterval(completed map[string][]Interval, ingestDirBase string, interval Interval) bool {
+func containsCompletedInterval(completed CompletedIndices, ingestDirBase string, interval Interval) bool {
 	intervals, ok := completed[ingestDirBase]
 	if !ok {
 		return false
@@ -730,7 +620,7 @@ func parseFileInterval(file string) (Interval, error) {
 
 // parseIntervalString parses the persisted `A-B` interval encoding.
 func parseIntervalString(value string) (Interval, error) {
-	groups := completedIntervalPattern.FindStringSubmatch(value)
+	groups := completedIntervalRe.FindStringSubmatch(value)
 	if len(groups) != 3 {
 		return Interval{}, fmt.Errorf("unexpected interval %q", value)
 	}
@@ -747,11 +637,6 @@ func parseIntervalString(value string) (Interval, error) {
 		return Interval{}, fmt.Errorf("unexpected interval %q", value)
 	}
 	return interval, nil
-}
-
-// String formats the interval using the persisted inclusive `A-B` form.
-func (i Interval) String() string {
-	return fmt.Sprintf("%d-%d", i.Start, i.End)
 }
 
 // syncDirAfterRename is a NOOP (read comment inside the function).

--- a/cmd/ingest/journal/journal.go
+++ b/cmd/ingest/journal/journal.go
@@ -15,11 +15,14 @@ import (
 )
 
 type Journal struct {
-	mu             sync.Mutex
-	closed         bool
-	closeOnce      sync.Once
-	JournalFile    string `json:"-"` // Exclude from JSON.
-	IngestDir      string `json:"-"` // Only used to refresh file listings.
+	mu          sync.Mutex
+	closed      bool
+	closeOnce   sync.Once
+	JournalFile string `json:"-"` // Exclude from JSON.
+	IngestDir   string `json:"-"` // Only used to refresh file listings.
+	// CurrentJob keeps the active run configuration available even though the
+	// persisted job history may contain entries from earlier invocations.
+	CurrentJob     Job `json:"-"`
 	Jobs           []Job
 	CompletedFiles map[string]map[string]struct{}
 }
@@ -29,6 +32,9 @@ type JobConfiguration struct {
 	Coalesce    bool
 	UpdateSMT   bool
 	FileBatch   int
+	// IncludePlainCSVs opts the run into also listing uncompressed `.csv`
+	// bundles. When false, ingest only discovers `.gz` inputs.
+	IncludePlainCSVs bool
 }
 
 type Job struct {
@@ -38,10 +44,12 @@ type Job struct {
 }
 
 // NewJobConfiguration translates the ingest strategy flags into the journal's
-// execution configuration.
-func NewJobConfiguration(strategy string, fileBatch int) (JobConfiguration, error) {
+// execution configuration, including whether plain `.csv` bundles should be
+// considered alongside compressed `.gz` files.
+func NewJobConfiguration(strategy string, fileBatch int, includePlainCSVs bool) (JobConfiguration, error) {
 	jc := JobConfiguration{
-		FileBatch: fileBatch,
+		FileBatch:        fileBatch,
+		IncludePlainCSVs: includePlainCSVs,
 	}
 	switch strategy {
 	case "onlyingest":
@@ -95,6 +103,7 @@ func NewJournal(journalFile string, cfg JobConfiguration, ingestDir string) (*Jo
 	}
 
 	j.registerShutdownHook()
+	j.CurrentJob = Job{JobConfiguration: cfg}
 	return j, nil
 }
 
@@ -162,7 +171,8 @@ func (j *Journal) reset(cfg JobConfiguration, ingestDir string) error {
 }
 
 // listFiles refreshes the current ingest directory listing and returns the
-// discovered CSV/GZ files in bundle order.
+// discovered input files in bundle order. Plain `.csv` files are only included
+// when the active job configuration explicitly enables them.
 func (j *Journal) listFiles() ([]string, error) {
 	if j.IngestDir == "" {
 		return nil, nil
@@ -180,7 +190,12 @@ func (j *Journal) listFiles() ([]string, error) {
 		return nil, err
 	}
 
-	files := append(gzFiles, csvFiles...)
+	files := slices.Clone(gzFiles)
+	// Default to the compressed bundle set and only opt into plain CSVs when
+	// the current invocation requested them.
+	if j.CurrentJob.JobConfiguration.IncludePlainCSVs {
+		files = append(files, csvFiles...)
+	}
 	if err := util.SortByBundleName(files); err != nil {
 		return nil, err
 	}
@@ -200,6 +215,7 @@ func (j *Journal) appendJob(cfg JobConfiguration) error {
 		Cmd:              slices.Clone(os.Args),
 		JobConfiguration: cfg,
 	})
+	j.CurrentJob = j.Jobs[len(j.Jobs)-1]
 
 	return nil
 }

--- a/cmd/ingest/journal/journal.go
+++ b/cmd/ingest/journal/journal.go
@@ -394,8 +394,7 @@ func (j *Journal) readAndClose(f *os.File) error {
 	return closeFile(f)
 }
 
-// decodeCompletedFiles accepts both the current interval-array encoding and the
-// legacy filename-set encoding, returning normalized interval coverage.
+// decodeCompletedFiles decodes the current interval-array encoding used on disk.
 func decodeCompletedFiles(raw json.RawMessage) (map[string][]Interval, error) {
 	if len(raw) == 0 || string(raw) == "null" {
 		return map[string][]Interval{}, nil
@@ -414,21 +413,6 @@ func decodeCompletedFiles(raw json.RawMessage) (map[string][]Interval, error) {
 				intervals = append(intervals, interval)
 			}
 			completed[ingestDirBase] = intervals
-		}
-		return completed, nil
-	}
-
-	var legacyFormat map[string]map[string]struct{}
-	if err := json.Unmarshal(raw, &legacyFormat); err == nil {
-		completed := make(map[string][]Interval, len(legacyFormat))
-		for ingestDirBase, files := range legacyFormat {
-			for fileBase := range files {
-				interval, err := parseFileInterval(fileBase)
-				if err != nil {
-					return nil, err
-				}
-				addCompletedInterval(completed, ingestDirBase, interval)
-			}
 		}
 		return completed, nil
 	}

--- a/cmd/ingest/journal/journal.go
+++ b/cmd/ingest/journal/journal.go
@@ -37,19 +37,6 @@ type Job struct {
 	JobConfiguration JobConfiguration `json:"JobConfiguration"`
 }
 
-type journalJSON struct {
-	Jobs             []Job                          `json:"Jobs"`
-	Cwds             []string                       `json:"Cwds"`
-	Cmds             [][]string                     `json:"Cmds"`
-	JobConfiguration JobConfiguration               `json:"JobConfiguration"`
-	CompletedFiles   map[string]map[string]struct{} `json:"CompletedFiles"`
-}
-
-type journalWriteJSON struct {
-	Jobs           []Job                          `json:"Jobs"`
-	CompletedFiles map[string]map[string]struct{} `json:"CompletedFiles"`
-}
-
 // NewJobConfiguration translates the ingest strategy flags into the journal's
 // execution configuration.
 func NewJobConfiguration(strategy string, fileBatch int) (JobConfiguration, error) {
@@ -255,10 +242,7 @@ func closeFile(f *os.File) error {
 
 // write encodes the journal to JSON and writes it to the provided file.
 func (j *Journal) write(f *os.File) error {
-	buf, err := json.MarshalIndent(journalWriteJSON{
-		Jobs:           j.Jobs,
-		CompletedFiles: j.CompletedFiles,
-	}, "", "  ")
+	buf, err := json.MarshalIndent(j, "", "  ")
 	if err != nil {
 		return fmt.Errorf("cannot translate journal to json: %w", err)
 	}
@@ -344,38 +328,17 @@ func (j *Journal) read(f *os.File) error {
 	if err != nil {
 		return fmt.Errorf("cannot read journal file: %w", err)
 	}
-	var raw journalJSON
+	var raw Journal
 	err = json.Unmarshal(buff, &raw)
 	if err != nil {
 		return fmt.Errorf("journal file wrong format: %w", err)
 	}
 	j.CompletedFiles = raw.CompletedFiles
 	j.Jobs = raw.Jobs
-	if len(j.Jobs) == 0 && (len(raw.Cwds) > 0 || len(raw.Cmds) > 0) {
-		j.Jobs = upgradeLegacyJobs(raw.Cwds, raw.Cmds, raw.JobConfiguration)
-	}
 	if err := j.normalize(); err != nil {
 		return fmt.Errorf("journal file wrong format: %w", err)
 	}
 	return nil
-}
-
-func upgradeLegacyJobs(cwds []string, cmds [][]string, cfg JobConfiguration) []Job {
-	n := max(len(cwds), len(cmds))
-	jobs := make([]Job, 0, n)
-	for i := 0; i < n; i++ {
-		job := Job{
-			JobConfiguration: cfg,
-		}
-		if i < len(cwds) {
-			job.Cwd = cwds[i]
-		}
-		if i < len(cmds) {
-			job.Cmd = slices.Clone(cmds[i])
-		}
-		jobs = append(jobs, job)
-	}
-	return jobs
 }
 
 // readAndClose reads the journal from disk and then closes the file handle.

--- a/cmd/ingest/journal/journal.go
+++ b/cmd/ingest/journal/journal.go
@@ -19,16 +19,13 @@ import (
 // Journal persists ingest progress so future runs can skip files whose
 // certificate-index ranges are already fully covered.
 type Journal struct {
-	mu          sync.Mutex
-	closed      bool
-	closeOnce   sync.Once
-	JournalFile string `json:"-"` // Exclude from JSON.
-	IngestDir   string `json:"-"` // Only used to refresh file listings.
-	// CurrentJob keeps the active run configuration available even though the
-	// persisted job history may contain entries from earlier invocations.
-	CurrentJob     Job `json:"-"`
-	Jobs           []Job
-	CompletedFiles map[string][]Interval
+	mu                   sync.Mutex
+	closed               bool
+	closeOnce            sync.Once
+	JournalFile          string `json:"-"` // Exclude from JSON.
+	IngestDir            string `json:"-"` // Only used to refresh file listings.
+	loadedCompletedFiles map[string][]Interval
+	Jobs                 []Job
 }
 
 // JobConfiguration captures the ingest-mode settings that affect how one run
@@ -45,9 +42,14 @@ type JobConfiguration struct {
 
 // Job records one invocation of the ingest command in the journal history.
 type Job struct {
-	Cwd              string           `json:"Cwd"`
-	Cmd              []string         `json:"Cmd"`
-	JobConfiguration JobConfiguration `json:"JobConfiguration"`
+	Cwd              string                 `json:"Cwd"`
+	Cmd              []string               `json:"Cmd"`
+	JobConfiguration JobConfiguration       `json:"JobConfiguration"`
+	StartTime        string                 `json:"StartTime"`
+	EndTime          string                 `json:"EndTime"`
+	Coalesced        bool                   `json:"Coalesced"`
+	UpdatedSMT       bool                   `json:"UpdatedSMT"`
+	CompletedIndices map[string][]Interval  `json:"-"`
 }
 
 // Interval represents an inclusive range of certificate indices.
@@ -87,9 +89,8 @@ func NewJobConfiguration(strategy string, fileBatch int, includePlainCSVs bool) 
 // completed-file entries into the journal key format.
 func NewJournal(journalFile string, cfg JobConfiguration, ingestDir string) (*Journal, error) {
 	j := &Journal{
-		JournalFile:    journalFile,
-		IngestDir:      ingestDir,
-		CompletedFiles: map[string][]Interval{},
+		JournalFile: journalFile,
+		IngestDir:   ingestDir,
 	}
 
 	// Check if file exists.
@@ -118,19 +119,22 @@ func NewJournal(journalFile string, cfg JobConfiguration, ingestDir string) (*Jo
 	}
 
 	j.registerShutdownHook()
-	j.CurrentJob = Job{JobConfiguration: cfg}
 	return j, nil
 }
 
-// AddCompletedFiles adds the file names to the set of completed intervals.
-// The function normalizes them into ingest-dir and interval keys and merges
-// them into the nested completed-interval slices.
-func (j *Journal) AddCompletedFiles(files []string) error {
+// CommitProgress updates the active job's completed-index snapshot, optional
+// phase flags, and end timestamp in one persisted journal write.
+func (j *Journal) CommitProgress(files []string, coalesced bool, updatedSMT bool) error {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
 	if j.closed {
-		return fmt.Errorf("cannot add completed files to closed journal")
+		return fmt.Errorf("cannot commit progress to closed journal")
+	}
+
+	job, err := j.currentJob()
+	if err != nil {
+		return err
 	}
 
 	for _, file := range files {
@@ -138,13 +142,15 @@ func (j *Journal) AddCompletedFiles(files []string) error {
 		if err != nil {
 			return err
 		}
-		addCompletedInterval(j.CompletedFiles, ingestDirBase, interval)
+		addCompletedInterval(job.CompletedIndices, ingestDirBase, interval)
 	}
+	job.Coalesced = coalesced
+	job.UpdatedSMT = updatedSMT
 	return j.writeLocked()
 }
 
-// PendingFiles returns the set subtraction LiveDirectoryListing - CompletedFiles.
-// CompletedFiles is expected to already contain normalized ingest-dir and
+// PendingFiles returns the set subtraction LiveDirectoryListing - CompletedIndices.
+// CompletedIndices is expected to already contain normalized ingest-dir and
 // interval coverage, so live files are normalized on the fly before coverage
 // is checked.
 func (j *Journal) PendingFiles() ([]string, error) {
@@ -159,6 +165,10 @@ func (j *Journal) PendingFiles() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	job, err := j.currentJob()
+	if err != nil {
+		return nil, err
+	}
 
 	pending := make([]string, 0, len(files))
 	for _, file := range files {
@@ -166,7 +176,7 @@ func (j *Journal) PendingFiles() ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		if containsCompletedInterval(j.CompletedFiles, ingestDirBase, interval) {
+		if containsCompletedInterval(job.CompletedIndices, ingestDirBase, interval) {
 			continue
 		}
 		pending = append(pending, file)
@@ -209,7 +219,11 @@ func (j *Journal) listFiles() ([]string, error) {
 	files := slices.Clone(gzFiles)
 	// Default to the compressed bundle set and only opt into plain CSVs when
 	// the current invocation requested them.
-	if j.CurrentJob.JobConfiguration.IncludePlainCSVs {
+	job, err := j.currentJob()
+	if err != nil {
+		return nil, err
+	}
+	if job.JobConfiguration.IncludePlainCSVs {
 		files = append(files, csvFiles...)
 	}
 	if err := util.SortByBundleName(files); err != nil {
@@ -226,12 +240,14 @@ func (j *Journal) appendJob(cfg JobConfiguration) error {
 	if err != nil {
 		return err
 	}
+
 	j.Jobs = append(j.Jobs, Job{
 		Cwd:              cwd,
 		Cmd:              slices.Clone(os.Args),
 		JobConfiguration: cfg,
+		StartTime:        time.Now().UTC().Format(time.RFC3339),
+		CompletedIndices: cloneCompletedIndices(j.latestCompletedIndices()),
 	})
-	j.CurrentJob = j.Jobs[len(j.Jobs)-1]
 
 	return nil
 }
@@ -288,6 +304,9 @@ func (j *Journal) write(f *os.File) error {
 
 // writeLocked atomically rewrites the journal file while the journal mutex is held.
 func (j *Journal) writeLocked() error {
+	if len(j.Jobs) > 0 {
+		j.Jobs[len(j.Jobs)-1].EndTime = time.Now().UTC().Format(time.RFC3339)
+	}
 	dir := filepath.Dir(j.JournalFile)
 	tempFile, err := os.CreateTemp(dir, filepath.Base(j.JournalFile)+".tmp-*")
 	if err != nil {
@@ -330,33 +349,23 @@ func (j *Journal) registerShutdownHook() {
 	})
 }
 
-// normalize restores the CompletedFiles invariant after loading JSON:
-// every entry must be stored as CompletedFiles[ingestDirBase] as a sorted,
+// normalize restores the CompletedIndices invariant after loading JSON:
+// every entry must be stored as CompletedIndices[ingestDirBase] as a sorted,
 // non-overlapping, minimal interval list.
 func (j *Journal) normalize() error {
-	if j.CompletedFiles == nil {
-		j.CompletedFiles = map[string][]Interval{}
-		return nil
+	for i := range j.Jobs {
+		normalized, err := normalizeCompletedIndices(j.Jobs[i].CompletedIndices)
+		if err != nil {
+			return fmt.Errorf("job %d: %w", i, err)
+		}
+		j.Jobs[i].CompletedIndices = normalized
 	}
 
-	for ingestDirBase, intervals := range j.CompletedFiles {
-		if ingestDirBase == "" {
-			return fmt.Errorf("empty ingest directory key in completed files")
-		}
-		if intervals == nil {
-			j.CompletedFiles[ingestDirBase] = []Interval{}
-			continue
-		}
-		normalized := make([]Interval, 0, len(intervals))
-		for _, interval := range intervals {
-			if interval.Start > interval.End {
-				return fmt.Errorf("invalid interval %s for ingest dir %q", interval.String(), ingestDirBase)
-			}
-			normalized = appendInterval(normalized, interval)
-		}
-		j.CompletedFiles[ingestDirBase] = normalized
+	normalizedLoaded, err := normalizeCompletedIndices(j.loadedCompletedFiles)
+	if err != nil {
+		return err
 	}
-
+	j.loadedCompletedFiles = normalizedLoaded
 	return nil
 }
 
@@ -366,20 +375,21 @@ func (j *Journal) read(f *os.File) error {
 	if err != nil {
 		return fmt.Errorf("cannot read journal file: %w", err)
 	}
-	var raw struct {
-		Jobs           []Job           `json:"Jobs"`
-		CompletedFiles json.RawMessage `json:"CompletedFiles"`
-	}
+	var raw rawJournal
 	err = json.Unmarshal(buff, &raw)
 	if err != nil {
 		return fmt.Errorf("journal file wrong format: %w", err)
 	}
-	j.Jobs = raw.Jobs
-	completedFiles, err := decodeCompletedFiles(raw.CompletedFiles)
+	jobs, err := decodeJobs(raw)
 	if err != nil {
 		return fmt.Errorf("journal file wrong format: %w", err)
 	}
-	j.CompletedFiles = completedFiles
+	j.Jobs = jobs
+	completedFiles, err := decodeCompletedIndices(raw.CompletedFiles)
+	if err != nil {
+		return fmt.Errorf("journal file wrong format: %w", err)
+	}
+	j.loadedCompletedFiles = completedFiles
 	if err := j.normalize(); err != nil {
 		return fmt.Errorf("journal file wrong format: %w", err)
 	}
@@ -394,8 +404,8 @@ func (j *Journal) readAndClose(f *os.File) error {
 	return closeFile(f)
 }
 
-// decodeCompletedFiles decodes the current interval-array encoding used on disk.
-func decodeCompletedFiles(raw json.RawMessage) (map[string][]Interval, error) {
+// decodeCompletedIndices decodes the current interval-array encoding used on disk.
+func decodeCompletedIndices(raw json.RawMessage) (map[string][]Interval, error) {
 	if len(raw) == 0 || string(raw) == "null" {
 		return map[string][]Interval{}, nil
 	}
@@ -417,30 +427,189 @@ func decodeCompletedFiles(raw json.RawMessage) (map[string][]Interval, error) {
 		return completed, nil
 	}
 
-	return nil, fmt.Errorf("unsupported completed files encoding")
+	return nil, fmt.Errorf("unsupported completed indices encoding")
 }
 
 // journalOnDisk is the persisted JSON shape for journal state.
 type journalOnDisk struct {
-	Jobs           []Job               `json:"Jobs"`
-	CompletedFiles map[string][]string `json:"CompletedFiles"`
+	Jobs []jobOnDisk `json:"Jobs"`
 }
 
 // MarshalJSON serializes the in-memory interval representation into the
 // human-readable on-disk string-array format.
 func (j *Journal) MarshalJSON() ([]byte, error) {
 	onDisk := journalOnDisk{
-		Jobs:           j.Jobs,
-		CompletedFiles: make(map[string][]string, len(j.CompletedFiles)),
+		Jobs: make([]jobOnDisk, 0, len(j.Jobs)),
 	}
-	for ingestDirBase, intervals := range j.CompletedFiles {
+	for _, job := range j.Jobs {
+		onDisk.Jobs = append(onDisk.Jobs, encodeJob(job))
+	}
+	return json.Marshal(onDisk)
+}
+
+type rawJournal struct {
+	Jobs             []rawJob          `json:"Jobs"`
+	CompletedFiles   json.RawMessage   `json:"CompletedFiles"`
+	Cwds             []string          `json:"Cwds"`
+	Cmds             [][]string        `json:"Cmds"`
+	JobConfiguration *JobConfiguration `json:"JobConfiguration"`
+}
+
+type rawJob struct {
+	Cwd              string           `json:"Cwd"`
+	Cmd              []string         `json:"Cmd"`
+	JobConfiguration JobConfiguration `json:"JobConfiguration"`
+	StartTime        string           `json:"StartTime"`
+	EndTime          string           `json:"EndTime"`
+	Coalesced        bool             `json:"Coalesced"`
+	UpdatedSMT       bool             `json:"UpdatedSMT"`
+	CompletedIndices json.RawMessage  `json:"CompletedIndices"`
+}
+
+type jobOnDisk struct {
+	Cwd              string              `json:"Cwd"`
+	Cmd              []string            `json:"Cmd"`
+	JobConfiguration JobConfiguration    `json:"JobConfiguration"`
+	StartTime        string              `json:"StartTime"`
+	EndTime          string              `json:"EndTime"`
+	Coalesced        bool                `json:"Coalesced"`
+	UpdatedSMT       bool                `json:"UpdatedSMT"`
+	CompletedIndices map[string][]string `json:"CompletedIndices"`
+}
+
+func decodeJobs(raw rawJournal) ([]Job, error) {
+	if len(raw.Jobs) > 0 {
+		jobs := make([]Job, 0, len(raw.Jobs))
+		for _, rawJob := range raw.Jobs {
+			completedIndices, err := decodeCompletedIndices(rawJob.CompletedIndices)
+			if err != nil {
+				return nil, err
+			}
+			jobs = append(jobs, Job{
+				Cwd:              rawJob.Cwd,
+				Cmd:              slices.Clone(rawJob.Cmd),
+				JobConfiguration: rawJob.JobConfiguration,
+				StartTime:        rawJob.StartTime,
+				EndTime:          rawJob.EndTime,
+				Coalesced:        rawJob.Coalesced,
+				UpdatedSMT:       rawJob.UpdatedSMT,
+				CompletedIndices: completedIndices,
+			})
+		}
+		return jobs, nil
+	}
+
+	count := max(len(raw.Cwds), len(raw.Cmds))
+	if raw.JobConfiguration != nil && count == 0 {
+		count = 1
+	}
+	if count == 0 {
+		return nil, nil
+	}
+
+	jobs := make([]Job, 0, count)
+	for i := 0; i < count; i++ {
+		job := Job{
+			CompletedIndices: map[string][]Interval{},
+		}
+		if i < len(raw.Cwds) {
+			job.Cwd = raw.Cwds[i]
+		}
+		if i < len(raw.Cmds) {
+			job.Cmd = slices.Clone(raw.Cmds[i])
+		}
+		if raw.JobConfiguration != nil {
+			job.JobConfiguration = *raw.JobConfiguration
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs, nil
+}
+
+func encodeJob(job Job) jobOnDisk {
+	return jobOnDisk{
+		Cwd:              job.Cwd,
+		Cmd:              slices.Clone(job.Cmd),
+		JobConfiguration: job.JobConfiguration,
+		StartTime:        job.StartTime,
+		EndTime:          job.EndTime,
+		Coalesced:        job.Coalesced,
+		UpdatedSMT:       job.UpdatedSMT,
+		CompletedIndices: encodeCompletedIndices(job.CompletedIndices),
+	}
+}
+
+func encodeCompletedIndices(completedIndices map[string][]Interval) map[string][]string {
+	encodedCompletedIndices := make(map[string][]string, len(completedIndices))
+	for ingestDirBase, intervals := range completedIndices {
 		encoded := make([]string, len(intervals))
 		for i, interval := range intervals {
 			encoded[i] = interval.String()
 		}
-		onDisk.CompletedFiles[ingestDirBase] = encoded
+		encodedCompletedIndices[ingestDirBase] = encoded
 	}
-	return json.Marshal(onDisk)
+	return encodedCompletedIndices
+}
+
+func normalizeCompletedIndices(completedIndices map[string][]Interval) (map[string][]Interval, error) {
+	if completedIndices == nil {
+		return map[string][]Interval{}, nil
+	}
+
+	normalizedCompletedIndices := make(map[string][]Interval, len(completedIndices))
+	for ingestDirBase, intervals := range completedIndices {
+		if ingestDirBase == "" {
+			return nil, fmt.Errorf("empty ingest directory key in completed indices")
+		}
+		if intervals == nil {
+			normalizedCompletedIndices[ingestDirBase] = []Interval{}
+			continue
+		}
+
+		normalized := make([]Interval, 0, len(intervals))
+		for _, interval := range intervals {
+			if interval.Start > interval.End {
+				return nil, fmt.Errorf("invalid interval %s for ingest dir %q", interval.String(), ingestDirBase)
+			}
+			normalized = appendInterval(normalized, interval)
+		}
+		normalizedCompletedIndices[ingestDirBase] = normalized
+	}
+	return normalizedCompletedIndices, nil
+}
+
+func cloneCompletedIndices(completedIndices map[string][]Interval) map[string][]Interval {
+	cloned := make(map[string][]Interval, len(completedIndices))
+	for ingestDirBase, intervals := range completedIndices {
+		cloned[ingestDirBase] = slices.Clone(intervals)
+	}
+	return cloned
+}
+
+func (j *Journal) latestCompletedIndices() map[string][]Interval {
+	if len(j.Jobs) == 0 {
+		return j.loadedCompletedFiles
+	}
+
+	completedIndices := j.Jobs[len(j.Jobs)-1].CompletedIndices
+	if len(completedIndices) > 0 {
+		return completedIndices
+	}
+	if len(j.loadedCompletedFiles) > 0 {
+		return j.loadedCompletedFiles
+	}
+	return completedIndices
+}
+
+func (j *Journal) currentJob() (*Job, error) {
+	if len(j.Jobs) == 0 {
+		return nil, fmt.Errorf("journal has no jobs")
+	}
+	job := &j.Jobs[len(j.Jobs)-1]
+	if job.CompletedIndices == nil {
+		job.CompletedIndices = map[string][]Interval{}
+	}
+	return job, nil
 }
 
 // addCompletedInterval inserts a completed interval into the nested set,

--- a/cmd/ingest/journal/journal.go
+++ b/cmd/ingest/journal/journal.go
@@ -15,16 +15,13 @@ import (
 )
 
 type Journal struct {
-	mu          sync.Mutex
-	closed      bool
-	closeOnce   sync.Once
-	JournalFile string     `json:"-"` // Exclude from JSON.
-	IngestDir   string     `json:"-"` // Only used to refresh file listings.
-	Cwds        []string   //`json:"Cwds"`
-	Cmds        [][]string //`json:"Cmds"`
-
-	JobConfiguration JobConfiguration //`json:"Configuration"`
-	CompletedFiles   map[string]map[string]struct{}
+	mu             sync.Mutex
+	closed         bool
+	closeOnce      sync.Once
+	JournalFile    string `json:"-"` // Exclude from JSON.
+	IngestDir      string `json:"-"` // Only used to refresh file listings.
+	Jobs           []Job
+	CompletedFiles map[string]map[string]struct{}
 }
 
 type JobConfiguration struct {
@@ -35,14 +32,22 @@ type JobConfiguration struct {
 }
 
 type Job struct {
-	Files []string //`json:"Files,omitempty"`
+	Cwd              string           `json:"Cwd"`
+	Cmd              []string         `json:"Cmd"`
+	JobConfiguration JobConfiguration `json:"JobConfiguration"`
 }
 
 type journalJSON struct {
+	Jobs             []Job                          `json:"Jobs"`
 	Cwds             []string                       `json:"Cwds"`
 	Cmds             [][]string                     `json:"Cmds"`
 	JobConfiguration JobConfiguration               `json:"JobConfiguration"`
 	CompletedFiles   map[string]map[string]struct{} `json:"CompletedFiles"`
+}
+
+type journalWriteJSON struct {
+	Jobs           []Job                          `json:"Jobs"`
+	CompletedFiles map[string]map[string]struct{} `json:"CompletedFiles"`
 }
 
 // NewJobConfiguration translates the ingest strategy flags into the journal's
@@ -93,7 +98,7 @@ func NewJournal(journalFile string, cfg JobConfiguration, ingestDir string) (*Jo
 			return nil, err
 		}
 
-		if err := j.updateCwdOsArgs(); err != nil {
+		if err := j.appendJob(cfg); err != nil {
 			return nil, err
 		}
 
@@ -160,12 +165,10 @@ func (j *Journal) PendingFiles() ([]string, error) {
 // reset initializes a new journal instance with the current run configuration.
 func (j *Journal) reset(cfg JobConfiguration, ingestDir string) error {
 	// Update first to get the current CWD and os.Args.
-	err := j.updateCwdOsArgs()
+	err := j.appendJob(cfg)
 	if err != nil {
 		return err
 	}
-
-	j.JobConfiguration = cfg
 	j.IngestDir = ingestDir
 
 	return j.Write()
@@ -198,16 +201,18 @@ func (j *Journal) listFiles() ([]string, error) {
 	return files, nil
 }
 
-// updateCwdOsArgs appends the current working directory and process arguments
-// to the journal history.
-func (j *Journal) updateCwdOsArgs() error {
-	// Append new command line and working directories.
+// appendJob records the current working directory, process arguments, and run
+// configuration as one journal history entry.
+func (j *Journal) appendJob(cfg JobConfiguration) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
 	}
-	j.Cwds = append(j.Cwds, cwd)
-	j.Cmds = append(j.Cmds, os.Args)
+	j.Jobs = append(j.Jobs, Job{
+		Cwd:              cwd,
+		Cmd:              slices.Clone(os.Args),
+		JobConfiguration: cfg,
+	})
 
 	return nil
 }
@@ -250,11 +255,9 @@ func closeFile(f *os.File) error {
 
 // write encodes the journal to JSON and writes it to the provided file.
 func (j *Journal) write(f *os.File) error {
-	buf, err := json.MarshalIndent(journalJSON{
-		Cwds:             j.Cwds,
-		Cmds:             j.Cmds,
-		JobConfiguration: j.JobConfiguration,
-		CompletedFiles:   j.CompletedFiles,
+	buf, err := json.MarshalIndent(journalWriteJSON{
+		Jobs:           j.Jobs,
+		CompletedFiles: j.CompletedFiles,
 	}, "", "  ")
 	if err != nil {
 		return fmt.Errorf("cannot translate journal to json: %w", err)
@@ -346,14 +349,33 @@ func (j *Journal) read(f *os.File) error {
 	if err != nil {
 		return fmt.Errorf("journal file wrong format: %w", err)
 	}
-	j.Cwds = raw.Cwds
-	j.Cmds = raw.Cmds
-	j.JobConfiguration = raw.JobConfiguration
 	j.CompletedFiles = raw.CompletedFiles
+	j.Jobs = raw.Jobs
+	if len(j.Jobs) == 0 && (len(raw.Cwds) > 0 || len(raw.Cmds) > 0) {
+		j.Jobs = upgradeLegacyJobs(raw.Cwds, raw.Cmds, raw.JobConfiguration)
+	}
 	if err := j.normalize(); err != nil {
 		return fmt.Errorf("journal file wrong format: %w", err)
 	}
 	return nil
+}
+
+func upgradeLegacyJobs(cwds []string, cmds [][]string, cfg JobConfiguration) []Job {
+	n := max(len(cwds), len(cmds))
+	jobs := make([]Job, 0, n)
+	for i := 0; i < n; i++ {
+		job := Job{
+			JobConfiguration: cfg,
+		}
+		if i < len(cwds) {
+			job.Cwd = cwds[i]
+		}
+		if i < len(cmds) {
+			job.Cmd = slices.Clone(cmds[i])
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs
 }
 
 // readAndClose reads the journal from disk and then closes the file handle.

--- a/cmd/ingest/journal/journal_test.go
+++ b/cmd/ingest/journal/journal_test.go
@@ -21,8 +21,8 @@ var csvFiles = [...]string{
 	"testdata/bundled/200000-299999.gz",
 }
 
-func completedIntervals(intervals ...Interval) map[string][]Interval {
-	return map[string][]Interval{
+func completedIntervals(intervals ...Interval) CompletedIndices {
+	return CompletedIndices{
 		"testdata": intervals,
 	}
 }
@@ -91,7 +91,11 @@ func TestNewJournal(t *testing.T) {
 
 	j, err = NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
-	require.Equal(t, completedIntervals(Interval{Start: 0, End: 99999}), latestJob(t, j).CompletedIndices)
+	require.Equal(
+		t,
+		completedIntervals(Interval{Start: 0, End: 99999}),
+		latestJob(t, j).CompletedIndices,
+	)
 	requireJSONDoesNotContainFiles(t, journalFile)
 }
 
@@ -101,7 +105,7 @@ func TestAddCompletedFilesIntervalScenarios(t *testing.T) {
 	testCases := map[string]struct {
 		setupJournal  func(*Journal)
 		addFiles      []string
-		wantCompleted map[string][]Interval
+		wantCompleted CompletedIndices
 		wantPending   []string
 	}{
 		"merges adjacent ranges": {
@@ -118,15 +122,15 @@ func TestAddCompletedFilesIntervalScenarios(t *testing.T) {
 				Interval{Start: 200000, End: 299999},
 			),
 			wantPending: []string{csvFiles[1]},
-			},
-			"bridges existing intervals": {
-				setupJournal: func(j *Journal) {
-					latestJob(t, j).CompletedIndices = map[string][]Interval{
-						"testdata": {
-							{Start: 0, End: 9},
-							{Start: 20, End: 29},
-						},
-					}
+		},
+		"bridges existing intervals": {
+			setupJournal: func(j *Journal) {
+				latestJob(t, j).CompletedIndices = CompletedIndices{
+					"testdata": {
+						{Start: 0, End: 9},
+						{Start: 20, End: 29},
+					},
+				}
 			},
 			addFiles: []string{
 				filepath.Join(csvPath, "bundled", "10-19.gz"),
@@ -231,35 +235,120 @@ func TestAppendInterval(t *testing.T) {
 	}
 }
 
-// TestContainsCompletedInterval verifies that coverage checks succeed only when
-// one stored interval fully contains the queried interval.
-func TestContainsCompletedInterval(t *testing.T) {
-	completed := map[string][]Interval{
-		"testdata": {
-			{Start: 0, End: 9},
-			{Start: 20, End: 39},
+// TestContainsCompletedIntervalScenarios verifies that coverage checks succeed
+// only when one stored interval fully contains the queried interval.
+func TestContainsCompletedIntervalScenarios(t *testing.T) {
+	testCases := map[string]struct {
+		completed     CompletedIndices
+		ingestDirBase string
+		query         Interval
+		want          bool
+	}{
+		"exact_interval_hit": {
+			completed: CompletedIndices{
+				"testdata": {
+					{Start: 0, End: 9},
+					{Start: 20, End: 39},
+				},
+			},
+			ingestDirBase: "testdata",
+			query:         Interval{Start: 0, End: 9},
+			want:          true,
+		},
+		"contained_sub_range": {
+			completed: CompletedIndices{
+				"testdata": {
+					{Start: 0, End: 9},
+					{Start: 20, End: 39},
+				},
+			},
+			ingestDirBase: "testdata",
+			query:         Interval{Start: 22, End: 25},
+			want:          true,
+		},
+		"second_interval_exact_hit": {
+			completed: CompletedIndices{
+				"testdata": {
+					{Start: 0, End: 9},
+					{Start: 20, End: 39},
+				},
+			},
+			ingestDirBase: "testdata",
+			query:         Interval{Start: 20, End: 39},
+			want:          true,
+		},
+		"overlaps_end_without_full_coverage": {
+			completed: CompletedIndices{
+				"testdata": {
+					{Start: 0, End: 9},
+					{Start: 20, End: 39},
+				},
+			},
+			ingestDirBase: "testdata",
+			query:         Interval{Start: 5, End: 10},
+			want:          false,
+		},
+		"gap_interval": {
+			completed: CompletedIndices{
+				"testdata": {
+					{Start: 0, End: 9},
+					{Start: 20, End: 39},
+				},
+			},
+			ingestDirBase: "testdata",
+			query:         Interval{Start: 10, End: 19},
+			want:          false,
+		},
+		"spanning_two_intervals": {
+			completed: CompletedIndices{
+				"testdata": {
+					{Start: 0, End: 9},
+					{Start: 20, End: 39},
+				},
+			},
+			ingestDirBase: "testdata",
+			query:         Interval{Start: 15, End: 25},
+			want:          false,
+		},
+		"missing_ingest_root": {
+			completed: CompletedIndices{
+				"testdata": {
+					{Start: 0, End: 9},
+					{Start: 20, End: 39},
+				},
+			},
+			ingestDirBase: "missing",
+			query:         Interval{Start: 0, End: 9},
+			want:          false,
 		},
 	}
 
-	require.True(t, containsCompletedInterval(completed, "testdata", Interval{Start: 0, End: 9}))
-	require.True(t, containsCompletedInterval(completed, "testdata", Interval{Start: 22, End: 25}))
-	require.True(t, containsCompletedInterval(completed, "testdata", Interval{Start: 20, End: 39}))
+	for name, tc := range testCases {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	require.False(t, containsCompletedInterval(completed, "testdata", Interval{Start: 5, End: 10}))
-	require.False(t, containsCompletedInterval(completed, "testdata", Interval{Start: 10, End: 19}))
-	require.False(t, containsCompletedInterval(completed, "testdata", Interval{Start: 15, End: 25}))
-	require.False(t, containsCompletedInterval(completed, "missing", Interval{Start: 0, End: 9}))
+			got := containsCompletedInterval(tc.completed, tc.ingestDirBase, tc.query)
+
+			require.Equal(t, tc.want, got)
+		})
+	}
 }
 
 // TestPendingFilesSkipsOnlyFullyCoveredFiles verifies that partially covered
 // files are still returned for processing.
 func TestPendingFilesSkipsOnlyFullyCoveredFiles(t *testing.T) {
-	root := makeEquivalentIngestRoot(t, "external", "partial-cover", []string{"0-9.gz", "10-19.gz", "20-29.gz"})
+	root := makeEquivalentIngestRoot(
+		t,
+		"external",
+		"partial-cover",
+		[]string{"0-9.gz", "10-19.gz", "20-29.gz"},
+	)
 	journalFile := filepath.Join(t.TempDir(), "journal.json")
 
 	j, err := NewJournal(journalFile, testJobConfig(t, false), root)
 	require.NoError(t, err)
-	latestJob(t, j).CompletedIndices = map[string][]Interval{
+	latestJob(t, j).CompletedIndices = CompletedIndices{
 		"partial-cover": {
 			{Start: 0, End: 8},
 			{Start: 20, End: 29},
@@ -274,110 +363,175 @@ func TestPendingFilesSkipsOnlyFullyCoveredFiles(t *testing.T) {
 	}, got)
 }
 
-// TestNewJournalInvalidJSON checks that malformed journal JSON is rejected.
-func TestNewJournalInvalidJSON(t *testing.T) {
-	journalFile := filepath.Join(t.TempDir(), "invalid.json")
-	err := os.WriteFile(journalFile, []byte("{"), 0o644)
-	require.NoError(t, err)
-
-	_, err = NewJournal(journalFile, testJobConfig(t, false), csvPath)
-	require.Error(t, err)
-}
-
-// TestNewJournalReadsIntervalCompletedFilesOnRead verifies that the new
-// human-readable interval encoding loads directly into in-memory intervals.
-func TestNewJournalReadsIntervalCompletedFilesOnRead(t *testing.T) {
-	journalFile := filepath.Join(t.TempDir(), "journal.json")
-	raw := map[string]any{
-		"CompletedFiles": map[string][]string{
-			"testdata": {"0-99999", "200000-299999"},
+// TestNewJournalReadScenarios verifies that current-format JSON is either read
+// successfully or rejected when malformed.
+func TestNewJournalReadScenarios(t *testing.T) {
+	testCases := map[string]struct {
+		rawJSON       []byte
+		ingestDir     string
+		wantErr       bool
+		wantCompleted CompletedIndices
+	}{
+		"malformed_json_bytes": {
+			rawJSON:   []byte("{"),
+			ingestDir: csvPath,
+			wantErr:   true,
+		},
+		"valid_job_with_two_completed_intervals": {
+			rawJSON: mustMarshalJSON(t, map[string]any{
+				"Jobs": []map[string]any{
+					{
+						"Cwd":              "/tmp",
+						"Cmd":              []string{"ingest"},
+						"JobConfiguration": testJobConfig(t, false),
+						"StartTime":        "2026-04-08T12:00:00Z",
+						"EndTime":          "2026-04-08T12:00:00Z",
+						"CompletedIndices": map[string][]string{
+							"testdata": {"0-99999", "200000-299999"},
+						},
+					},
+				},
+			}),
+			ingestDir: csvPath,
+			wantCompleted: completedIntervals(
+				Interval{Start: 0, End: 99999},
+				Interval{Start: 200000, End: 299999},
+			),
+		},
+		"valid_job_with_malformed_interval_string": {
+			rawJSON: mustMarshalJSON(t, map[string]any{
+				"Jobs": []map[string]any{
+					{
+						"Cwd":              "/tmp",
+						"Cmd":              []string{"ingest"},
+						"JobConfiguration": testJobConfig(t, false),
+						"StartTime":        "2026-04-08T12:00:00Z",
+						"EndTime":          "2026-04-08T12:00:00Z",
+						"CompletedIndices": map[string][]string{
+							"testdata": {"20-10"},
+						},
+					},
+				},
+			}),
+			ingestDir: csvPath,
+			wantErr:   true,
 		},
 	}
-	buf, err := json.Marshal(raw)
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(journalFile, buf, 0o644))
 
-	j, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
-	require.NoError(t, err)
-	require.Equal(t, completedIntervals(
-		Interval{Start: 0, End: 99999},
-		Interval{Start: 200000, End: 299999},
-	), latestJob(t, j).CompletedIndices)
+	for name, tc := range testCases {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			journalFile := filepath.Join(t.TempDir(), "journal.json")
+			require.NoError(t, os.WriteFile(journalFile, tc.rawJSON, 0o644))
+
+			j, err := NewJournal(journalFile, testJobConfig(t, false), tc.ingestDir)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.wantCompleted, latestJob(t, j).CompletedIndices)
+		})
+	}
 }
 
-// TestPendingFilesEquivalentIngestRootsShareProgress verifies that equivalent
-// ingest roots with the same basename share completed-file state.
-func TestPendingFilesEquivalentIngestRootsShareProgress(t *testing.T) {
-	firstRoot := makeEquivalentIngestRoot(t, "external", "same-log", []string{"0-9.gz", "10-19.gz"})
-	secondRoot := makeEquivalentIngestRoot(t, "data", "same-log", []string{"0-9.gz", "10-19.gz", "20-29.gz"})
-
-	journalFile := filepath.Join(t.TempDir(), "journal.json")
-	j, err := NewJournal(journalFile, testJobConfig(t, false), firstRoot)
-	require.NoError(t, err)
-	require.NoError(t, j.CommitProgress([]string{
-		filepath.Join(firstRoot, "bundled", "0-9.gz"),
-		filepath.Join(firstRoot, "bundled", "10-19.gz"),
-	}, false, false))
-
-	j, err = NewJournal(journalFile, testJobConfig(t, false), secondRoot)
-	require.NoError(t, err)
-
-	got, err := j.PendingFiles()
-	require.NoError(t, err)
-	require.Equal(t, []string{filepath.Join(secondRoot, "bundled", "20-29.gz")}, got)
-}
-
-// TestPendingFilesDifferentIngestRootBasenamesDoNotShareProgress verifies that
-// different ingest-dir basenames do not share completed-file state.
-func TestPendingFilesDifferentIngestRootBasenamesDoNotShareProgress(t *testing.T) {
-	firstRoot := makeEquivalentIngestRoot(t, "external", "log-a", []string{"0-9.gz"})
-	secondRoot := makeEquivalentIngestRoot(t, "data", "log-b", []string{"0-9.gz"})
-
-	journalFile := filepath.Join(t.TempDir(), "journal.json")
-	j, err := NewJournal(journalFile, testJobConfig(t, false), firstRoot)
-	require.NoError(t, err)
-	require.NoError(t, j.CommitProgress([]string{filepath.Join(firstRoot, "bundled", "0-9.gz")}, false, false))
-
-	j, err = NewJournal(journalFile, testJobConfig(t, false), secondRoot)
-	require.NoError(t, err)
-
-	got, err := j.PendingFiles()
-	require.NoError(t, err)
-	require.Equal(t, []string{filepath.Join(secondRoot, "bundled", "0-9.gz")}, got)
-}
-
-// TestCommitProgressDeduplicatesEquivalentRoots checks that adding the same
-// normalized file through equivalent ingest roots remains idempotent.
-func TestCommitProgressDeduplicatesEquivalentRoots(t *testing.T) {
-	firstRoot := makeEquivalentIngestRoot(t, "external", "same-log", []string{"0-9.gz"})
-	secondRoot := makeEquivalentIngestRoot(t, "data", "same-log", []string{"0-9.gz"})
-
-	journalFile := filepath.Join(t.TempDir(), "journal.json")
-	j, err := NewJournal(journalFile, testJobConfig(t, false), firstRoot)
-	require.NoError(t, err)
-
-	require.NoError(t, j.CommitProgress([]string{
-		filepath.Join(firstRoot, "bundled", "0-9.gz"),
-		filepath.Join(secondRoot, "bundled", "0-9.gz"),
-	}, false, false))
-	require.Equal(t, map[string][]Interval{"same-log": {{Start: 0, End: 9}}}, latestJob(t, j).CompletedIndices)
-}
-
-// TestNewJournalRejectsMalformedIntervalString verifies that reversed or
-// otherwise invalid interval strings are rejected on load.
-func TestNewJournalRejectsMalformedIntervalString(t *testing.T) {
-	journalFile := filepath.Join(t.TempDir(), "journal.json")
-	raw := map[string]any{
-		"CompletedFiles": map[string][]string{
-			"testdata": {"20-10"},
+// TestEquivalentIngestRootProgressScenarios verifies basename-based progress
+// sharing and equivalent-root deduplication behavior.
+func TestEquivalentIngestRootProgressScenarios(t *testing.T) {
+	testCases := map[string]struct {
+		firstBase      string
+		secondBase     string
+		firstFiles     []string
+		secondFiles    []string
+		commitFiles    func(firstRoot, secondRoot string) []string
+		reopenOnSecond bool
+		wantPending    []string
+		wantCompleted  CompletedIndices
+	}{
+		"same_basename_shares_progress_across_reopen": {
+			firstBase:   "same-log",
+			secondBase:  "same-log",
+			firstFiles:  []string{"0-9.gz", "10-19.gz"},
+			secondFiles: []string{"0-9.gz", "10-19.gz", "20-29.gz"},
+			commitFiles: func(firstRoot, _ string) []string {
+				return []string{
+					filepath.Join(firstRoot, "bundled", "0-9.gz"),
+					filepath.Join(firstRoot, "bundled", "10-19.gz"),
+				}
+			},
+			reopenOnSecond: true,
+			wantPending: []string{
+				filepath.Join("ROOT", "bundled", "20-29.gz"),
+			},
+		},
+		"different_basenames_do_not_share_progress": {
+			firstBase:   "log-a",
+			secondBase:  "log-b",
+			firstFiles:  []string{"0-9.gz"},
+			secondFiles: []string{"0-9.gz"},
+			commitFiles: func(firstRoot, _ string) []string {
+				return []string{
+					filepath.Join(firstRoot, "bundled", "0-9.gz"),
+				}
+			},
+			reopenOnSecond: true,
+			wantPending: []string{
+				filepath.Join("ROOT", "bundled", "0-9.gz"),
+			},
+		},
+		"duplicate_commit_from_equivalent_roots_stays_deduplicated": {
+			firstBase:   "same-log",
+			secondBase:  "same-log",
+			firstFiles:  []string{"0-9.gz"},
+			secondFiles: []string{"0-9.gz"},
+			commitFiles: func(firstRoot, secondRoot string) []string {
+				return []string{
+					filepath.Join(firstRoot, "bundled", "0-9.gz"),
+					filepath.Join(secondRoot, "bundled", "0-9.gz"),
+				}
+			},
+			wantCompleted: CompletedIndices{
+				"same-log": {{Start: 0, End: 9}},
+			},
 		},
 	}
-	buf, err := json.Marshal(raw)
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(journalFile, buf, 0o644))
 
-	_, err = NewJournal(journalFile, testJobConfig(t, false), csvPath)
-	require.Error(t, err)
+	for name, tc := range testCases {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			firstRoot := makeEquivalentIngestRoot(t, "external", tc.firstBase, tc.firstFiles)
+			secondRoot := makeEquivalentIngestRoot(t, "data", tc.secondBase, tc.secondFiles)
+
+			journalFile := filepath.Join(t.TempDir(), "journal.json")
+			j, err := NewJournal(journalFile, testJobConfig(t, false), firstRoot)
+			require.NoError(t, err)
+
+			require.NoError(
+				t,
+				j.CommitProgress(tc.commitFiles(firstRoot, secondRoot), false, false),
+			)
+
+			if tc.wantCompleted != nil {
+				require.Equal(t, tc.wantCompleted, latestJob(t, j).CompletedIndices)
+			}
+
+			if !tc.reopenOnSecond {
+				return
+			}
+
+			j, err = NewJournal(journalFile, testJobConfig(t, false), secondRoot)
+			require.NoError(t, err)
+
+			got, err := j.PendingFiles()
+			require.NoError(t, err)
+			require.Equal(t, replaceRootPlaceholder(tc.wantPending, secondRoot), got)
+		})
+	}
 }
 
 // TestClosePersistsAndIsIdempotent verifies that Close flushes state and can be
@@ -394,7 +548,11 @@ func TestClosePersistsAndIsIdempotent(t *testing.T) {
 
 	reopened, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
-	require.Equal(t, completedIntervals(Interval{Start: 0, End: 99999}), latestJob(t, reopened).CompletedIndices)
+	require.Equal(
+		t,
+		completedIntervals(Interval{Start: 0, End: 99999}),
+		latestJob(t, reopened).CompletedIndices,
+	)
 }
 
 // TestPendingFilesUsesFreshDirectoryListing verifies that PendingFiles always
@@ -423,40 +581,46 @@ func TestPendingFilesUsesFreshDirectoryListing(t *testing.T) {
 	require.Equal(t, []string{firstFile, secondFile}, got)
 }
 
-// TestPendingFilesExcludesPlainCSVsByDefault verifies that plain `.csv` files
-// stay hidden unless the run configuration opts into them.
-func TestPendingFilesExcludesPlainCSVsByDefault(t *testing.T) {
-	root := makeMixedIngestRoot(t)
-	journalFile := filepath.Join(t.TempDir(), "journal.json")
+// TestPendingFilesPlainCSVScenarios verifies that plain CSV discovery follows
+// the IncludePlainCSVs configuration.
+func TestPendingFilesPlainCSVScenarios(t *testing.T) {
+	testCases := map[string]struct {
+		includePlainCSVs bool
+		want             []string
+	}{
+		"plain_csvs_excluded_by_default": {
+			want: []string{
+				filepath.Join("ROOT", "bundled", "0-9.gz"),
+				filepath.Join("ROOT", "bundled", "10-19.gz"),
+			},
+		},
+		"plain_csvs_included_when_enabled": {
+			includePlainCSVs: true,
+			want: []string{
+				filepath.Join("ROOT", "bundled", "0-9.gz"),
+				filepath.Join("ROOT", "bundled", "10-19.gz"),
+				filepath.Join("ROOT", "20-29.csv"),
+				filepath.Join("ROOT", "30-39.csv"),
+			},
+		},
+	}
 
-	j, err := NewJournal(journalFile, testJobConfig(t, false), root)
-	require.NoError(t, err)
+	for name, tc := range testCases {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	got, err := j.PendingFiles()
-	require.NoError(t, err)
-	require.Equal(t, []string{
-		filepath.Join(root, "bundled", "0-9.gz"),
-		filepath.Join(root, "bundled", "10-19.gz"),
-	}, got)
-}
+			root := makeMixedIngestRoot(t)
+			journalFile := filepath.Join(t.TempDir(), "journal.json")
 
-// TestPendingFilesIncludesPlainCSVsWhenEnabled verifies that enabling the flag
-// restores mixed `.gz` and `.csv` discovery.
-func TestPendingFilesIncludesPlainCSVsWhenEnabled(t *testing.T) {
-	root := makeMixedIngestRoot(t)
-	journalFile := filepath.Join(t.TempDir(), "journal.json")
+			j, err := NewJournal(journalFile, testJobConfig(t, tc.includePlainCSVs), root)
+			require.NoError(t, err)
 
-	j, err := NewJournal(journalFile, testJobConfig(t, true), root)
-	require.NoError(t, err)
-
-	got, err := j.PendingFiles()
-	require.NoError(t, err)
-	require.Equal(t, []string{
-		filepath.Join(root, "bundled", "0-9.gz"),
-		filepath.Join(root, "bundled", "10-19.gz"),
-		filepath.Join(root, "20-29.csv"),
-		filepath.Join(root, "30-39.csv"),
-	}, got)
+			got, err := j.PendingFiles()
+			require.NoError(t, err)
+			require.Equal(t, replaceRootPlaceholder(tc.want, root), got)
+		})
+	}
 }
 
 // requireJSONDoesNotContainFiles asserts that the journal JSON does not use the
@@ -475,6 +639,21 @@ func latestJob(t *testing.T, j *Journal) *Job {
 	return &j.Jobs[len(j.Jobs)-1]
 }
 
+func mustMarshalJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	buf, err := json.Marshal(value)
+	require.NoError(t, err)
+	return buf
+}
+
+func replaceRootPlaceholder(paths []string, root string) []string {
+	replaced := make([]string, len(paths))
+	for i, path := range paths {
+		replaced[i] = strings.Replace(path, "ROOT", root, 1)
+	}
+	return replaced
+}
+
 // testJobConfig returns a JobConfiguration with "onlyingest" and batch size of 2.
 func testJobConfig(t *testing.T, includePlainCSVs bool) JobConfiguration {
 	t.Helper()
@@ -485,7 +664,12 @@ func testJobConfig(t *testing.T, includePlainCSVs bool) JobConfiguration {
 
 // makeEquivalentIngestRoot creates a temporary ingest directory tree with the
 // requested basename and bundled files.
-func makeEquivalentIngestRoot(t *testing.T, parent string, ingestBase string, files []string) string {
+func makeEquivalentIngestRoot(
+	t *testing.T,
+	parent string,
+	ingestBase string,
+	files []string,
+) string {
 	t.Helper()
 
 	root := filepath.Join(t.TempDir(), parent, ingestBase)

--- a/cmd/ingest/journal/journal_test.go
+++ b/cmd/ingest/journal/journal_test.go
@@ -20,21 +20,12 @@ var csvFiles = [...]string{
 	"testdata/bundled/200000-299999.gz",
 }
 
-var normalizedCSVFiles = [...]string{
-	"testdata/0-99999.gz",
-	"testdata/100000-199999.gz",
-	"testdata/200000-299999.gz",
-}
-
-func normalizedCSVSet(indices ...int) map[string]map[string]struct{} {
-	files := map[string]map[string]struct{}{}
-	for _, i := range indices {
-		addCompletedFile(files, "testdata", filepath.Base(normalizedCSVFiles[i]))
+func completedIntervals(intervals ...Interval) map[string][]Interval {
+	return map[string][]Interval{
+		"testdata": intervals,
 	}
-	return files
 }
 
-// TestSanityOfThisTest verifies that the content of the testdata/bundled directory is as expected.
 // TestSanityOfThisTest verifies that the bundled testdata fixtures are present
 // and that ListCsvFiles returns them as expected.
 func TestSanityOfThisTest(t *testing.T) {
@@ -49,8 +40,6 @@ func TestSanityOfThisTest(t *testing.T) {
 	}
 }
 
-// TestPerformanceListCsvFiles is used mainly in the production server, to assess how long
-// it takes to list a directory. Typically used when the working directory is the USB.
 // TestPerformanceListCsvFiles logs the runtime and counts for a full directory
 // scan, mainly as a lightweight benchmark/debug aid.
 func TestPerformanceListCsvFiles(t *testing.T) {
@@ -65,7 +54,7 @@ func TestPerformanceListCsvFiles(t *testing.T) {
 }
 
 // TestNewJournal checks journal creation, reopening, and persistence of a
-// newly completed file.
+// newly completed interval.
 func TestNewJournal(t *testing.T) {
 	journalFile := filepath.Join(t.TempDir(), fmt.Sprintf("%s.json", t.Name()))
 
@@ -76,7 +65,6 @@ func TestNewJournal(t *testing.T) {
 	require.Empty(t, j.CompletedFiles)
 	requireJSONDoesNotContainFiles(t, journalFile)
 
-	// Recreate.
 	j, err = NewJournal(journalFile, testJobConfig(t, false), "")
 	require.NoError(t, err)
 	require.Equal(t, journalFile, j.JournalFile)
@@ -84,7 +72,6 @@ func TestNewJournal(t *testing.T) {
 	require.Empty(t, j.CompletedFiles)
 	requireJSONDoesNotContainFiles(t, journalFile)
 
-	// Recreate, with existing non-processed files.
 	journalFile = filepath.Join(t.TempDir(), "with-files.json")
 	j, err = NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
@@ -94,19 +81,18 @@ func TestNewJournal(t *testing.T) {
 	require.Empty(t, j.CompletedFiles)
 	requireJSONDoesNotContainFiles(t, journalFile)
 
-	// Add one file as completed.
 	err = j.AddCompletedFiles(csvFiles[:1])
 	require.NoError(t, err)
-	// Check that the completed file is there.
+
 	j, err = NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
-	require.Equal(t, normalizedCSVSet(0), j.CompletedFiles)
+	require.Equal(t, completedIntervals(Interval{Start: 0, End: 99999}), j.CompletedFiles)
 	requireJSONDoesNotContainFiles(t, journalFile)
 }
 
-// TestAddCompletedFiles checks that AddCompletedFiles correctly adds the file names,
-// and that the nested set is kept deduplicated.
-func TestAddCompletedFiles(t *testing.T) {
+// TestAddCompletedFilesMergesAdjacentRanges verifies that adding consecutive
+// completed files coalesces them into one interval.
+func TestAddCompletedFilesMergesAdjacentRanges(t *testing.T) {
 	journalFile := filepath.Join(t.TempDir(), fmt.Sprintf("%s.json", t.Name()))
 
 	j, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
@@ -116,39 +102,147 @@ func TestAddCompletedFiles(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, csvFiles[:], got)
 
-	// Add the first file 0-99999.
-	err = j.AddCompletedFiles(csvFiles[0:1])
-	require.NoError(t, err)
-	require.Equal(t, normalizedCSVSet(0), j.CompletedFiles)
+	require.NoError(t, j.AddCompletedFiles(csvFiles[0:1]))
+	require.Equal(t, completedIntervals(Interval{Start: 0, End: 99999}), j.CompletedFiles)
 	got, err = j.PendingFiles()
 	require.NoError(t, err)
 	require.Equal(t, []string{csvFiles[1], csvFiles[2]}, got)
 
-	// Add the last file 200000-299999.
-	err = j.AddCompletedFiles(csvFiles[2:3])
-	require.NoError(t, err)
+	require.NoError(t, j.AddCompletedFiles(csvFiles[1:2]))
+	require.Equal(t, completedIntervals(Interval{Start: 0, End: 199999}), j.CompletedFiles)
 	got, err = j.PendingFiles()
 	require.NoError(t, err)
-	require.Equal(t, []string{csvFiles[1]}, got)
-	require.Len(t, got, 1)
-	// Check that indeed the pending file is the second from csvFiles 100000-199999.
-	require.Equal(t, csvFiles[1], got[0])
+	require.Equal(t, []string{csvFiles[2]}, got)
 }
 
-// TestPendingFiles verifies that completed files are excluded from the pending
-// file list.
-func TestPendingFiles(t *testing.T) {
+// TestAddCompletedFilesKeepsGaps verifies that missing files remain represented
+// as gaps between completed intervals.
+func TestAddCompletedFilesKeepsGaps(t *testing.T) {
 	journalFile := filepath.Join(t.TempDir(), fmt.Sprintf("%s.json", t.Name()))
 
 	j, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
 
-	err = j.AddCompletedFiles([]string{csvFiles[0], csvFiles[2]})
-	require.NoError(t, err)
+	require.NoError(t, j.AddCompletedFiles([]string{csvFiles[0], csvFiles[2]}))
+
+	require.Equal(t, completedIntervals(
+		Interval{Start: 0, End: 99999},
+		Interval{Start: 200000, End: 299999},
+	), j.CompletedFiles)
 
 	got, err := j.PendingFiles()
 	require.NoError(t, err)
 	require.Equal(t, []string{csvFiles[1]}, got)
+}
+
+// TestAddCompletedFilesBridgesIntervals verifies that inserting a middle range
+// joins two neighboring completed intervals.
+func TestAddCompletedFilesBridgesIntervals(t *testing.T) {
+	completed := map[string][]Interval{
+		"testdata": {
+			{Start: 0, End: 9},
+			{Start: 20, End: 29},
+		},
+	}
+
+	addCompletedInterval(completed, "testdata", Interval{Start: 10, End: 19})
+
+	require.Equal(t, completedIntervals(Interval{Start: 0, End: 29}), completed)
+}
+
+// TestAppendInterval exercises direct interval insertion and merging behavior
+// independent of the higher-level journal APIs.
+func TestAppendInterval(t *testing.T) {
+	t.Run("insert disjoint interval in order", func(t *testing.T) {
+		got := appendInterval([]Interval{
+			{Start: 0, End: 9},
+			{Start: 20, End: 29},
+		}, Interval{Start: 40, End: 49})
+
+		require.Equal(t, []Interval{
+			{Start: 0, End: 9},
+			{Start: 20, End: 29},
+			{Start: 40, End: 49},
+		}, got)
+	})
+
+	t.Run("merge adjacent predecessor", func(t *testing.T) {
+		got := appendInterval([]Interval{
+			{Start: 0, End: 9},
+			{Start: 20, End: 29},
+		}, Interval{Start: 10, End: 19})
+
+		require.Equal(t, []Interval{
+			{Start: 0, End: 29},
+		}, got)
+	})
+
+	t.Run("merge overlapping successor", func(t *testing.T) {
+		got := appendInterval([]Interval{
+			{Start: 20, End: 29},
+			{Start: 40, End: 49},
+		}, Interval{Start: 25, End: 45})
+
+		require.Equal(t, []Interval{
+			{Start: 20, End: 49},
+		}, got)
+	})
+
+	t.Run("insert before first interval", func(t *testing.T) {
+		got := appendInterval([]Interval{
+			{Start: 20, End: 29},
+			{Start: 40, End: 49},
+		}, Interval{Start: 0, End: 9})
+
+		require.Equal(t, []Interval{
+			{Start: 0, End: 9},
+			{Start: 20, End: 29},
+			{Start: 40, End: 49},
+		}, got)
+	})
+}
+
+// TestContainsCompletedInterval verifies that coverage checks succeed only when
+// one stored interval fully contains the queried interval.
+func TestContainsCompletedInterval(t *testing.T) {
+	completed := map[string][]Interval{
+		"testdata": {
+			{Start: 0, End: 9},
+			{Start: 20, End: 39},
+		},
+	}
+
+	require.True(t, containsCompletedInterval(completed, "testdata", Interval{Start: 0, End: 9}))
+	require.True(t, containsCompletedInterval(completed, "testdata", Interval{Start: 22, End: 25}))
+	require.True(t, containsCompletedInterval(completed, "testdata", Interval{Start: 20, End: 39}))
+
+	require.False(t, containsCompletedInterval(completed, "testdata", Interval{Start: 5, End: 10}))
+	require.False(t, containsCompletedInterval(completed, "testdata", Interval{Start: 10, End: 19}))
+	require.False(t, containsCompletedInterval(completed, "testdata", Interval{Start: 15, End: 25}))
+	require.False(t, containsCompletedInterval(completed, "missing", Interval{Start: 0, End: 9}))
+}
+
+// TestPendingFilesSkipsOnlyFullyCoveredFiles verifies that partially covered
+// files are still returned for processing.
+func TestPendingFilesSkipsOnlyFullyCoveredFiles(t *testing.T) {
+	root := makeEquivalentIngestRoot(t, "external", "partial-cover", []string{"0-9.gz", "10-19.gz", "20-29.gz"})
+	journalFile := filepath.Join(t.TempDir(), "journal.json")
+
+	j, err := NewJournal(journalFile, testJobConfig(t, false), root)
+	require.NoError(t, err)
+	j.CompletedFiles = map[string][]Interval{
+		"partial-cover": {
+			{Start: 0, End: 8},
+			{Start: 20, End: 29},
+		},
+	}
+
+	got, err := j.PendingFiles()
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		filepath.Join(root, "bundled", "0-9.gz"),
+		filepath.Join(root, "bundled", "10-19.gz"),
+	}, got)
 }
 
 // TestNewJournalInvalidJSON checks that malformed journal JSON is rejected.
@@ -161,14 +255,15 @@ func TestNewJournalInvalidJSON(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestNewJournalReadsNestedCompletedFilesOnRead verifies that the current
-// nested CompletedFiles JSON format is loaded into the in-memory nested set.
-func TestNewJournalReadsNestedCompletedFilesOnRead(t *testing.T) {
+// TestNewJournalReadsLegacyCompletedFilesOnRead verifies that the legacy
+// filename-set encoding is loaded and normalized into intervals.
+func TestNewJournalReadsLegacyCompletedFilesOnRead(t *testing.T) {
 	journalFile := filepath.Join(t.TempDir(), "journal.json")
 	raw := map[string]any{
 		"CompletedFiles": map[string]map[string]struct{}{
 			"testdata": {
 				"0-99999.gz":       {},
+				"100000-199999.gz": {},
 				"200000-299999.gz": {},
 			},
 		},
@@ -180,7 +275,28 @@ func TestNewJournalReadsNestedCompletedFilesOnRead(t *testing.T) {
 	j, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
 
-	require.Equal(t, normalizedCSVSet(0, 2), j.CompletedFiles)
+	require.Equal(t, completedIntervals(Interval{Start: 0, End: 299999}), j.CompletedFiles)
+}
+
+// TestNewJournalReadsIntervalCompletedFilesOnRead verifies that the new
+// human-readable interval encoding loads directly into in-memory intervals.
+func TestNewJournalReadsIntervalCompletedFilesOnRead(t *testing.T) {
+	journalFile := filepath.Join(t.TempDir(), "journal.json")
+	raw := map[string]any{
+		"CompletedFiles": map[string][]string{
+			"testdata": {"0-99999", "200000-299999"},
+		},
+	}
+	buf, err := json.Marshal(raw)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(journalFile, buf, 0o644))
+
+	j, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
+	require.NoError(t, err)
+	require.Equal(t, completedIntervals(
+		Interval{Start: 0, End: 99999},
+		Interval{Start: 200000, End: 299999},
+	), j.CompletedFiles)
 }
 
 // TestPendingFilesEquivalentIngestRootsShareProgress verifies that equivalent
@@ -238,7 +354,7 @@ func TestAddCompletedFilesDeduplicatesEquivalentRoots(t *testing.T) {
 		filepath.Join(firstRoot, "bundled", "0-9.gz"),
 		filepath.Join(secondRoot, "bundled", "0-9.gz"),
 	}))
-	require.Equal(t, map[string]map[string]struct{}{"same-log": {"0-9.gz": {}}}, j.CompletedFiles)
+	require.Equal(t, map[string][]Interval{"same-log": {{Start: 0, End: 9}}}, j.CompletedFiles)
 }
 
 // TestNewJournalRejectsMalformedCompletedFilesEncoding verifies that an
@@ -256,9 +372,26 @@ func TestNewJournalRejectsMalformedCompletedFilesEncoding(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestWritePersistsNestedCompletedFilesJSON verifies that Write persists
-// CompletedFiles using the nested JSON object format.
-func TestWritePersistsNestedCompletedFilesJSON(t *testing.T) {
+// TestNewJournalRejectsMalformedIntervalString verifies that reversed or
+// otherwise invalid interval strings are rejected on load.
+func TestNewJournalRejectsMalformedIntervalString(t *testing.T) {
+	journalFile := filepath.Join(t.TempDir(), "journal.json")
+	raw := map[string]any{
+		"CompletedFiles": map[string][]string{
+			"testdata": {"20-10"},
+		},
+	}
+	buf, err := json.Marshal(raw)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(journalFile, buf, 0o644))
+
+	_, err = NewJournal(journalFile, testJobConfig(t, false), csvPath)
+	require.Error(t, err)
+}
+
+// TestWritePersistsIntervalCompletedFilesJSON verifies that Write persists
+// CompletedFiles using the new interval-array JSON format.
+func TestWritePersistsIntervalCompletedFilesJSON(t *testing.T) {
 	journalFile := filepath.Join(t.TempDir(), "journal.json")
 	j, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
@@ -270,11 +403,15 @@ func TestWritePersistsNestedCompletedFilesJSON(t *testing.T) {
 	var raw map[string]json.RawMessage
 	require.NoError(t, json.Unmarshal(buf, &raw))
 
-	var completed map[string]map[string]struct{}
+	var completed map[string][]string
 	require.NoError(t, json.Unmarshal(raw["CompletedFiles"], &completed))
-	require.Equal(t, normalizedCSVSet(0, 2), completed)
+	require.Equal(t, map[string][]string{
+		"testdata": {"0-99999", "200000-299999"},
+	}, completed)
 }
 
+// TestWritePersistsJobsJSON verifies that job history is still written in the
+// dedicated Jobs field rather than flattened legacy fields.
 func TestWritePersistsJobsJSON(t *testing.T) {
 	journalFile := filepath.Join(t.TempDir(), "journal.json")
 	_, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
@@ -301,19 +438,21 @@ func TestWritePersistsJobsJSON(t *testing.T) {
 	require.False(t, hasJobConfig)
 }
 
+// TestClosePersistsAndIsIdempotent verifies that Close flushes state and can be
+// called multiple times safely.
 func TestClosePersistsAndIsIdempotent(t *testing.T) {
 	journalFile := filepath.Join(t.TempDir(), "journal.json")
 	j, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
 
-	addCompletedFile(j.CompletedFiles, "testdata", "0-99999.gz")
+	addCompletedInterval(j.CompletedFiles, "testdata", Interval{Start: 0, End: 99999})
 
 	require.NoError(t, j.Close())
 	require.NoError(t, j.Close())
 
 	reopened, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
-	require.Equal(t, normalizedCSVSet(0), reopened.CompletedFiles)
+	require.Equal(t, completedIntervals(Interval{Start: 0, End: 99999}), reopened.CompletedFiles)
 }
 
 // TestPendingFilesUsesFreshDirectoryListing verifies that PendingFiles always
@@ -342,6 +481,8 @@ func TestPendingFilesUsesFreshDirectoryListing(t *testing.T) {
 	require.Equal(t, []string{firstFile, secondFile}, got)
 }
 
+// TestPendingFilesExcludesPlainCSVsByDefault verifies that plain `.csv` files
+// stay hidden unless the run configuration opts into them.
 func TestPendingFilesExcludesPlainCSVsByDefault(t *testing.T) {
 	root := makeMixedIngestRoot(t)
 	journalFile := filepath.Join(t.TempDir(), "journal.json")
@@ -357,6 +498,8 @@ func TestPendingFilesExcludesPlainCSVsByDefault(t *testing.T) {
 	}, got)
 }
 
+// TestPendingFilesIncludesPlainCSVsWhenEnabled verifies that enabling the flag
+// restores mixed `.gz` and `.csv` discovery.
 func TestPendingFilesIncludesPlainCSVsWhenEnabled(t *testing.T) {
 	root := makeMixedIngestRoot(t)
 	journalFile := filepath.Join(t.TempDir(), "journal.json")
@@ -374,6 +517,8 @@ func TestPendingFilesIncludesPlainCSVsWhenEnabled(t *testing.T) {
 	}, got)
 }
 
+// requireJSONDoesNotContainFiles asserts that the journal JSON does not use the
+// long-removed Files field.
 func requireJSONDoesNotContainFiles(t *testing.T, journalFile string) {
 	t.Helper()
 	buf, err := os.ReadFile(journalFile)
@@ -389,6 +534,8 @@ func testJobConfig(t *testing.T, includePlainCSVs bool) JobConfiguration {
 	return cfg
 }
 
+// makeEquivalentIngestRoot creates a temporary ingest directory tree with the
+// requested basename and bundled files.
 func makeEquivalentIngestRoot(t *testing.T, parent string, ingestBase string, files []string) string {
 	t.Helper()
 
@@ -401,6 +548,8 @@ func makeEquivalentIngestRoot(t *testing.T, parent string, ingestBase string, fi
 	return root
 }
 
+// makeMixedIngestRoot creates an ingest directory containing both bundled `.gz`
+// files and top-level plain `.csv` files.
 func makeMixedIngestRoot(t *testing.T) string {
 	t.Helper()
 

--- a/cmd/ingest/journal/journal_test.go
+++ b/cmd/ingest/journal/journal_test.go
@@ -69,7 +69,7 @@ func TestPerformanceListCsvFiles(t *testing.T) {
 func TestNewJournal(t *testing.T) {
 	journalFile := filepath.Join(t.TempDir(), fmt.Sprintf("%s.json", t.Name()))
 
-	j, err := NewJournal(journalFile, testJobConfig(t), "")
+	j, err := NewJournal(journalFile, testJobConfig(t, false), "")
 	require.NoError(t, err)
 	require.Equal(t, journalFile, j.JournalFile)
 	require.FileExists(t, journalFile)
@@ -77,7 +77,7 @@ func TestNewJournal(t *testing.T) {
 	requireJSONDoesNotContainFiles(t, journalFile)
 
 	// Recreate.
-	j, err = NewJournal(journalFile, testJobConfig(t), "")
+	j, err = NewJournal(journalFile, testJobConfig(t, false), "")
 	require.NoError(t, err)
 	require.Equal(t, journalFile, j.JournalFile)
 	require.FileExists(t, journalFile)
@@ -86,7 +86,7 @@ func TestNewJournal(t *testing.T) {
 
 	// Recreate, with existing non-processed files.
 	journalFile = filepath.Join(t.TempDir(), "with-files.json")
-	j, err = NewJournal(journalFile, testJobConfig(t), csvPath)
+	j, err = NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
 	got, err := j.PendingFiles()
 	require.NoError(t, err)
@@ -98,7 +98,7 @@ func TestNewJournal(t *testing.T) {
 	err = j.AddCompletedFiles(csvFiles[:1])
 	require.NoError(t, err)
 	// Check that the completed file is there.
-	j, err = NewJournal(journalFile, testJobConfig(t), csvPath)
+	j, err = NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
 	require.Equal(t, normalizedCSVSet(0), j.CompletedFiles)
 	requireJSONDoesNotContainFiles(t, journalFile)
@@ -109,7 +109,7 @@ func TestNewJournal(t *testing.T) {
 func TestAddCompletedFiles(t *testing.T) {
 	journalFile := filepath.Join(t.TempDir(), fmt.Sprintf("%s.json", t.Name()))
 
-	j, err := NewJournal(journalFile, testJobConfig(t), csvPath)
+	j, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
 
 	got, err := j.PendingFiles()
@@ -140,7 +140,7 @@ func TestAddCompletedFiles(t *testing.T) {
 func TestPendingFiles(t *testing.T) {
 	journalFile := filepath.Join(t.TempDir(), fmt.Sprintf("%s.json", t.Name()))
 
-	j, err := NewJournal(journalFile, testJobConfig(t), csvPath)
+	j, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
 
 	err = j.AddCompletedFiles([]string{csvFiles[0], csvFiles[2]})
@@ -157,7 +157,7 @@ func TestNewJournalInvalidJSON(t *testing.T) {
 	err := os.WriteFile(journalFile, []byte("{"), 0o644)
 	require.NoError(t, err)
 
-	_, err = NewJournal(journalFile, testJobConfig(t), csvPath)
+	_, err = NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.Error(t, err)
 }
 
@@ -177,7 +177,7 @@ func TestNewJournalReadsNestedCompletedFilesOnRead(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(journalFile, buf, 0o644))
 
-	j, err := NewJournal(journalFile, testJobConfig(t), csvPath)
+	j, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
 
 	require.Equal(t, normalizedCSVSet(0, 2), j.CompletedFiles)
@@ -190,14 +190,14 @@ func TestPendingFilesEquivalentIngestRootsShareProgress(t *testing.T) {
 	secondRoot := makeEquivalentIngestRoot(t, "data", "same-log", []string{"0-9.gz", "10-19.gz", "20-29.gz"})
 
 	journalFile := filepath.Join(t.TempDir(), "journal.json")
-	j, err := NewJournal(journalFile, testJobConfig(t), firstRoot)
+	j, err := NewJournal(journalFile, testJobConfig(t, false), firstRoot)
 	require.NoError(t, err)
 	require.NoError(t, j.AddCompletedFiles([]string{
 		filepath.Join(firstRoot, "bundled", "0-9.gz"),
 		filepath.Join(firstRoot, "bundled", "10-19.gz"),
 	}))
 
-	j, err = NewJournal(journalFile, testJobConfig(t), secondRoot)
+	j, err = NewJournal(journalFile, testJobConfig(t, false), secondRoot)
 	require.NoError(t, err)
 
 	got, err := j.PendingFiles()
@@ -212,11 +212,11 @@ func TestPendingFilesDifferentIngestRootBasenamesDoNotShareProgress(t *testing.T
 	secondRoot := makeEquivalentIngestRoot(t, "data", "log-b", []string{"0-9.gz"})
 
 	journalFile := filepath.Join(t.TempDir(), "journal.json")
-	j, err := NewJournal(journalFile, testJobConfig(t), firstRoot)
+	j, err := NewJournal(journalFile, testJobConfig(t, false), firstRoot)
 	require.NoError(t, err)
 	require.NoError(t, j.AddCompletedFiles([]string{filepath.Join(firstRoot, "bundled", "0-9.gz")}))
 
-	j, err = NewJournal(journalFile, testJobConfig(t), secondRoot)
+	j, err = NewJournal(journalFile, testJobConfig(t, false), secondRoot)
 	require.NoError(t, err)
 
 	got, err := j.PendingFiles()
@@ -231,7 +231,7 @@ func TestAddCompletedFilesDeduplicatesEquivalentRoots(t *testing.T) {
 	secondRoot := makeEquivalentIngestRoot(t, "data", "same-log", []string{"0-9.gz"})
 
 	journalFile := filepath.Join(t.TempDir(), "journal.json")
-	j, err := NewJournal(journalFile, testJobConfig(t), firstRoot)
+	j, err := NewJournal(journalFile, testJobConfig(t, false), firstRoot)
 	require.NoError(t, err)
 
 	require.NoError(t, j.AddCompletedFiles([]string{
@@ -252,7 +252,7 @@ func TestNewJournalRejectsMalformedCompletedFilesEncoding(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(journalFile, buf, 0o644))
 
-	_, err = NewJournal(journalFile, testJobConfig(t), csvPath)
+	_, err = NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.Error(t, err)
 }
 
@@ -260,7 +260,7 @@ func TestNewJournalRejectsMalformedCompletedFilesEncoding(t *testing.T) {
 // CompletedFiles using the nested JSON object format.
 func TestWritePersistsNestedCompletedFilesJSON(t *testing.T) {
 	journalFile := filepath.Join(t.TempDir(), "journal.json")
-	j, err := NewJournal(journalFile, testJobConfig(t), csvPath)
+	j, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
 	require.NoError(t, j.AddCompletedFiles([]string{csvFiles[0], csvFiles[2]}))
 
@@ -277,7 +277,7 @@ func TestWritePersistsNestedCompletedFilesJSON(t *testing.T) {
 
 func TestWritePersistsJobsJSON(t *testing.T) {
 	journalFile := filepath.Join(t.TempDir(), "journal.json")
-	_, err := NewJournal(journalFile, testJobConfig(t), csvPath)
+	_, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
 
 	buf, err := os.ReadFile(journalFile)
@@ -291,7 +291,7 @@ func TestWritePersistsJobsJSON(t *testing.T) {
 	require.Len(t, jobs, 1)
 	require.NotEmpty(t, jobs[0].Cwd)
 	require.NotEmpty(t, jobs[0].Cmd)
-	require.Equal(t, testJobConfig(t), jobs[0].JobConfiguration)
+	require.Equal(t, testJobConfig(t, false), jobs[0].JobConfiguration)
 
 	_, hasCwds := raw["Cwds"]
 	_, hasCmds := raw["Cmds"]
@@ -303,7 +303,7 @@ func TestWritePersistsJobsJSON(t *testing.T) {
 
 func TestClosePersistsAndIsIdempotent(t *testing.T) {
 	journalFile := filepath.Join(t.TempDir(), "journal.json")
-	j, err := NewJournal(journalFile, testJobConfig(t), csvPath)
+	j, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
 
 	addCompletedFile(j.CompletedFiles, "testdata", "0-99999.gz")
@@ -311,7 +311,7 @@ func TestClosePersistsAndIsIdempotent(t *testing.T) {
 	require.NoError(t, j.Close())
 	require.NoError(t, j.Close())
 
-	reopened, err := NewJournal(journalFile, testJobConfig(t), csvPath)
+	reopened, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
 	require.Equal(t, normalizedCSVSet(0), reopened.CompletedFiles)
 }
@@ -327,7 +327,7 @@ func TestPendingFilesUsesFreshDirectoryListing(t *testing.T) {
 	require.NoError(t, os.WriteFile(firstFile, nil, 0o644))
 
 	journalFile := filepath.Join(t.TempDir(), "journal.json")
-	j, err := NewJournal(journalFile, testJobConfig(t), root)
+	j, err := NewJournal(journalFile, testJobConfig(t, false), root)
 	require.NoError(t, err)
 
 	got, err := j.PendingFiles()
@@ -342,6 +342,38 @@ func TestPendingFilesUsesFreshDirectoryListing(t *testing.T) {
 	require.Equal(t, []string{firstFile, secondFile}, got)
 }
 
+func TestPendingFilesExcludesPlainCSVsByDefault(t *testing.T) {
+	root := makeMixedIngestRoot(t)
+	journalFile := filepath.Join(t.TempDir(), "journal.json")
+
+	j, err := NewJournal(journalFile, testJobConfig(t, false), root)
+	require.NoError(t, err)
+
+	got, err := j.PendingFiles()
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		filepath.Join(root, "bundled", "0-9.gz"),
+		filepath.Join(root, "bundled", "10-19.gz"),
+	}, got)
+}
+
+func TestPendingFilesIncludesPlainCSVsWhenEnabled(t *testing.T) {
+	root := makeMixedIngestRoot(t)
+	journalFile := filepath.Join(t.TempDir(), "journal.json")
+
+	j, err := NewJournal(journalFile, testJobConfig(t, true), root)
+	require.NoError(t, err)
+
+	got, err := j.PendingFiles()
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		filepath.Join(root, "bundled", "0-9.gz"),
+		filepath.Join(root, "bundled", "10-19.gz"),
+		filepath.Join(root, "20-29.csv"),
+		filepath.Join(root, "30-39.csv"),
+	}, got)
+}
+
 func requireJSONDoesNotContainFiles(t *testing.T, journalFile string) {
 	t.Helper()
 	buf, err := os.ReadFile(journalFile)
@@ -350,9 +382,9 @@ func requireJSONDoesNotContainFiles(t *testing.T, journalFile string) {
 }
 
 // testJobConfig returns a JobConfiguration with "onlyingest" and batch size of 2.
-func testJobConfig(t *testing.T) JobConfiguration {
+func testJobConfig(t *testing.T, includePlainCSVs bool) JobConfiguration {
 	t.Helper()
-	cfg, err := NewJobConfiguration("onlyingest", 2)
+	cfg, err := NewJobConfiguration("onlyingest", 2, includePlainCSVs)
 	require.NoError(t, err)
 	return cfg
 }
@@ -365,6 +397,21 @@ func makeEquivalentIngestRoot(t *testing.T, parent string, ingestBase string, fi
 	require.NoError(t, os.MkdirAll(bundledDir, 0o755))
 	for _, name := range files {
 		require.NoError(t, os.WriteFile(filepath.Join(bundledDir, name), nil, 0o644))
+	}
+	return root
+}
+
+func makeMixedIngestRoot(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	bundledDir := filepath.Join(root, "bundled")
+	require.NoError(t, os.MkdirAll(bundledDir, 0o755))
+	for _, name := range []string{"0-9.gz", "10-19.gz"} {
+		require.NoError(t, os.WriteFile(filepath.Join(bundledDir, name), nil, 0o644))
+	}
+	for _, name := range []string{"20-29.csv", "30-39.csv"} {
+		require.NoError(t, os.WriteFile(filepath.Join(root, name), nil, 0o644))
 	}
 	return root
 }

--- a/cmd/ingest/journal/journal_test.go
+++ b/cmd/ingest/journal/journal_test.go
@@ -63,14 +63,18 @@ func TestNewJournal(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, journalFile, j.JournalFile)
 	require.FileExists(t, journalFile)
-	require.Empty(t, j.CompletedFiles)
+	require.Empty(t, latestJob(t, j).CompletedIndices)
+	require.NotEmpty(t, latestJob(t, j).StartTime)
+	require.NotEmpty(t, latestJob(t, j).EndTime)
+	require.False(t, latestJob(t, j).Coalesced)
+	require.False(t, latestJob(t, j).UpdatedSMT)
 	requireJSONDoesNotContainFiles(t, journalFile)
 
 	j, err = NewJournal(journalFile, testJobConfig(t, false), "")
 	require.NoError(t, err)
 	require.Equal(t, journalFile, j.JournalFile)
 	require.FileExists(t, journalFile)
-	require.Empty(t, j.CompletedFiles)
+	require.Empty(t, latestJob(t, j).CompletedIndices)
 	requireJSONDoesNotContainFiles(t, journalFile)
 
 	journalFile = filepath.Join(t.TempDir(), "with-files.json")
@@ -79,15 +83,15 @@ func TestNewJournal(t *testing.T) {
 	got, err := j.PendingFiles()
 	require.NoError(t, err)
 	require.Len(t, got, len(csvFiles))
-	require.Empty(t, j.CompletedFiles)
+	require.Empty(t, latestJob(t, j).CompletedIndices)
 	requireJSONDoesNotContainFiles(t, journalFile)
 
-	err = j.AddCompletedFiles(csvFiles[:1])
+	err = j.CommitProgress(csvFiles[:1], false, false)
 	require.NoError(t, err)
 
 	j, err = NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
-	require.Equal(t, completedIntervals(Interval{Start: 0, End: 99999}), j.CompletedFiles)
+	require.Equal(t, completedIntervals(Interval{Start: 0, End: 99999}), latestJob(t, j).CompletedIndices)
 	requireJSONDoesNotContainFiles(t, journalFile)
 }
 
@@ -114,15 +118,15 @@ func TestAddCompletedFilesIntervalScenarios(t *testing.T) {
 				Interval{Start: 200000, End: 299999},
 			),
 			wantPending: []string{csvFiles[1]},
-		},
-		"bridges existing intervals": {
-			setupJournal: func(j *Journal) {
-				j.CompletedFiles = map[string][]Interval{
-					"testdata": {
-						{Start: 0, End: 9},
-						{Start: 20, End: 29},
-					},
-				}
+			},
+			"bridges existing intervals": {
+				setupJournal: func(j *Journal) {
+					latestJob(t, j).CompletedIndices = map[string][]Interval{
+						"testdata": {
+							{Start: 0, End: 9},
+							{Start: 20, End: 29},
+						},
+					}
 			},
 			addFiles: []string{
 				filepath.Join(csvPath, "bundled", "10-19.gz"),
@@ -151,8 +155,8 @@ func TestAddCompletedFilesIntervalScenarios(t *testing.T) {
 				tc.setupJournal(j)
 			}
 
-			require.NoError(t, j.AddCompletedFiles(tc.addFiles))
-			require.Equal(t, tc.wantCompleted, j.CompletedFiles)
+			require.NoError(t, j.CommitProgress(tc.addFiles, false, false))
+			require.Equal(t, tc.wantCompleted, latestJob(t, j).CompletedIndices)
 
 			got, err := j.PendingFiles()
 			require.NoError(t, err)
@@ -255,7 +259,7 @@ func TestPendingFilesSkipsOnlyFullyCoveredFiles(t *testing.T) {
 
 	j, err := NewJournal(journalFile, testJobConfig(t, false), root)
 	require.NoError(t, err)
-	j.CompletedFiles = map[string][]Interval{
+	latestJob(t, j).CompletedIndices = map[string][]Interval{
 		"partial-cover": {
 			{Start: 0, End: 8},
 			{Start: 20, End: 29},
@@ -298,7 +302,7 @@ func TestNewJournalReadsIntervalCompletedFilesOnRead(t *testing.T) {
 	require.Equal(t, completedIntervals(
 		Interval{Start: 0, End: 99999},
 		Interval{Start: 200000, End: 299999},
-	), j.CompletedFiles)
+	), latestJob(t, j).CompletedIndices)
 }
 
 // TestPendingFilesEquivalentIngestRootsShareProgress verifies that equivalent
@@ -310,10 +314,10 @@ func TestPendingFilesEquivalentIngestRootsShareProgress(t *testing.T) {
 	journalFile := filepath.Join(t.TempDir(), "journal.json")
 	j, err := NewJournal(journalFile, testJobConfig(t, false), firstRoot)
 	require.NoError(t, err)
-	require.NoError(t, j.AddCompletedFiles([]string{
+	require.NoError(t, j.CommitProgress([]string{
 		filepath.Join(firstRoot, "bundled", "0-9.gz"),
 		filepath.Join(firstRoot, "bundled", "10-19.gz"),
-	}))
+	}, false, false))
 
 	j, err = NewJournal(journalFile, testJobConfig(t, false), secondRoot)
 	require.NoError(t, err)
@@ -332,7 +336,7 @@ func TestPendingFilesDifferentIngestRootBasenamesDoNotShareProgress(t *testing.T
 	journalFile := filepath.Join(t.TempDir(), "journal.json")
 	j, err := NewJournal(journalFile, testJobConfig(t, false), firstRoot)
 	require.NoError(t, err)
-	require.NoError(t, j.AddCompletedFiles([]string{filepath.Join(firstRoot, "bundled", "0-9.gz")}))
+	require.NoError(t, j.CommitProgress([]string{filepath.Join(firstRoot, "bundled", "0-9.gz")}, false, false))
 
 	j, err = NewJournal(journalFile, testJobConfig(t, false), secondRoot)
 	require.NoError(t, err)
@@ -342,9 +346,9 @@ func TestPendingFilesDifferentIngestRootBasenamesDoNotShareProgress(t *testing.T
 	require.Equal(t, []string{filepath.Join(secondRoot, "bundled", "0-9.gz")}, got)
 }
 
-// TestAddCompletedFilesDeduplicatesEquivalentRoots checks that adding the same
+// TestCommitProgressDeduplicatesEquivalentRoots checks that adding the same
 // normalized file through equivalent ingest roots remains idempotent.
-func TestAddCompletedFilesDeduplicatesEquivalentRoots(t *testing.T) {
+func TestCommitProgressDeduplicatesEquivalentRoots(t *testing.T) {
 	firstRoot := makeEquivalentIngestRoot(t, "external", "same-log", []string{"0-9.gz"})
 	secondRoot := makeEquivalentIngestRoot(t, "data", "same-log", []string{"0-9.gz"})
 
@@ -352,11 +356,11 @@ func TestAddCompletedFilesDeduplicatesEquivalentRoots(t *testing.T) {
 	j, err := NewJournal(journalFile, testJobConfig(t, false), firstRoot)
 	require.NoError(t, err)
 
-	require.NoError(t, j.AddCompletedFiles([]string{
+	require.NoError(t, j.CommitProgress([]string{
 		filepath.Join(firstRoot, "bundled", "0-9.gz"),
 		filepath.Join(secondRoot, "bundled", "0-9.gz"),
-	}))
-	require.Equal(t, map[string][]Interval{"same-log": {{Start: 0, End: 9}}}, j.CompletedFiles)
+	}, false, false))
+	require.Equal(t, map[string][]Interval{"same-log": {{Start: 0, End: 9}}}, latestJob(t, j).CompletedIndices)
 }
 
 // TestNewJournalRejectsMalformedIntervalString verifies that reversed or
@@ -383,14 +387,14 @@ func TestClosePersistsAndIsIdempotent(t *testing.T) {
 	j, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
 
-	addCompletedInterval(j.CompletedFiles, "testdata", Interval{Start: 0, End: 99999})
+	addCompletedInterval(latestJob(t, j).CompletedIndices, "testdata", Interval{Start: 0, End: 99999})
 
 	require.NoError(t, j.Close())
 	require.NoError(t, j.Close())
 
 	reopened, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
-	require.Equal(t, completedIntervals(Interval{Start: 0, End: 99999}), reopened.CompletedFiles)
+	require.Equal(t, completedIntervals(Interval{Start: 0, End: 99999}), latestJob(t, reopened).CompletedIndices)
 }
 
 // TestPendingFilesUsesFreshDirectoryListing verifies that PendingFiles always
@@ -462,6 +466,13 @@ func requireJSONDoesNotContainFiles(t *testing.T, journalFile string) {
 	buf, err := os.ReadFile(journalFile)
 	require.NoError(t, err)
 	require.NotContains(t, string(buf), "\"Files\"")
+	require.NotContains(t, string(buf), "\"CompletedFiles\"")
+}
+
+func latestJob(t *testing.T, j *Journal) *Job {
+	t.Helper()
+	require.NotEmpty(t, j.Jobs)
+	return &j.Jobs[len(j.Jobs)-1]
 }
 
 // testJobConfig returns a JobConfiguration with "onlyingest" and batch size of 2.

--- a/cmd/ingest/journal/journal_test.go
+++ b/cmd/ingest/journal/journal_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -90,116 +91,140 @@ func TestNewJournal(t *testing.T) {
 	requireJSONDoesNotContainFiles(t, journalFile)
 }
 
-// TestAddCompletedFilesMergesAdjacentRanges verifies that adding consecutive
-// completed files coalesces them into one interval.
-func TestAddCompletedFilesMergesAdjacentRanges(t *testing.T) {
-	journalFile := filepath.Join(t.TempDir(), fmt.Sprintf("%s.json", t.Name()))
-
-	j, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
-	require.NoError(t, err)
-
-	got, err := j.PendingFiles()
-	require.NoError(t, err)
-	require.Equal(t, csvFiles[:], got)
-
-	require.NoError(t, j.AddCompletedFiles(csvFiles[0:1]))
-	require.Equal(t, completedIntervals(Interval{Start: 0, End: 99999}), j.CompletedFiles)
-	got, err = j.PendingFiles()
-	require.NoError(t, err)
-	require.Equal(t, []string{csvFiles[1], csvFiles[2]}, got)
-
-	require.NoError(t, j.AddCompletedFiles(csvFiles[1:2]))
-	require.Equal(t, completedIntervals(Interval{Start: 0, End: 199999}), j.CompletedFiles)
-	got, err = j.PendingFiles()
-	require.NoError(t, err)
-	require.Equal(t, []string{csvFiles[2]}, got)
-}
-
-// TestAddCompletedFilesKeepsGaps verifies that missing files remain represented
-// as gaps between completed intervals.
-func TestAddCompletedFilesKeepsGaps(t *testing.T) {
-	journalFile := filepath.Join(t.TempDir(), fmt.Sprintf("%s.json", t.Name()))
-
-	j, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
-	require.NoError(t, err)
-
-	require.NoError(t, j.AddCompletedFiles([]string{csvFiles[0], csvFiles[2]}))
-
-	require.Equal(t, completedIntervals(
-		Interval{Start: 0, End: 99999},
-		Interval{Start: 200000, End: 299999},
-	), j.CompletedFiles)
-
-	got, err := j.PendingFiles()
-	require.NoError(t, err)
-	require.Equal(t, []string{csvFiles[1]}, got)
-}
-
-// TestAddCompletedFilesBridgesIntervals verifies that inserting a middle range
-// joins two neighboring completed intervals.
-func TestAddCompletedFilesBridgesIntervals(t *testing.T) {
-	completed := map[string][]Interval{
-		"testdata": {
-			{Start: 0, End: 9},
-			{Start: 20, End: 29},
+// TestAddCompletedFilesIntervalScenarios verifies that completed files are
+// merged into minimal intervals while preserving gaps when coverage is missing.
+func TestAddCompletedFilesIntervalScenarios(t *testing.T) {
+	testCases := map[string]struct {
+		setupJournal  func(*Journal)
+		addFiles      []string
+		wantCompleted map[string][]Interval
+		wantPending   []string
+	}{
+		"merges adjacent ranges": {
+			addFiles: []string{csvFiles[0], csvFiles[1]},
+			wantCompleted: completedIntervals(
+				Interval{Start: 0, End: 199999},
+			),
+			wantPending: []string{csvFiles[2]},
+		},
+		"keeps gaps": {
+			addFiles: []string{csvFiles[0], csvFiles[2]},
+			wantCompleted: completedIntervals(
+				Interval{Start: 0, End: 99999},
+				Interval{Start: 200000, End: 299999},
+			),
+			wantPending: []string{csvFiles[1]},
+		},
+		"bridges existing intervals": {
+			setupJournal: func(j *Journal) {
+				j.CompletedFiles = map[string][]Interval{
+					"testdata": {
+						{Start: 0, End: 9},
+						{Start: 20, End: 29},
+					},
+				}
+			},
+			addFiles: []string{
+				filepath.Join(csvPath, "bundled", "10-19.gz"),
+			},
+			wantCompleted: completedIntervals(
+				Interval{Start: 0, End: 29},
+			),
+			wantPending: csvFiles[:],
 		},
 	}
 
-	addCompletedInterval(completed, "testdata", Interval{Start: 10, End: 19})
+	for name, tc := range testCases {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	require.Equal(t, completedIntervals(Interval{Start: 0, End: 29}), completed)
+			journalFile := filepath.Join(
+				t.TempDir(),
+				fmt.Sprintf("%s.json", strings.ReplaceAll(t.Name(), "/", "-")),
+			)
+
+			j, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
+			require.NoError(t, err)
+
+			if tc.setupJournal != nil {
+				tc.setupJournal(j)
+			}
+
+			require.NoError(t, j.AddCompletedFiles(tc.addFiles))
+			require.Equal(t, tc.wantCompleted, j.CompletedFiles)
+
+			got, err := j.PendingFiles()
+			require.NoError(t, err)
+			require.Equal(t, tc.wantPending, got)
+		})
+	}
 }
 
 // TestAppendInterval exercises direct interval insertion and merging behavior
 // independent of the higher-level journal APIs.
 func TestAppendInterval(t *testing.T) {
-	t.Run("insert disjoint interval in order", func(t *testing.T) {
-		got := appendInterval([]Interval{
-			{Start: 0, End: 9},
-			{Start: 20, End: 29},
-		}, Interval{Start: 40, End: 49})
+	testCases := map[string]struct {
+		intervals []Interval
+		append    Interval
+		want      []Interval
+	}{
+		"insert disjoint interval in order": {
+			intervals: []Interval{
+				{Start: 0, End: 9},
+				{Start: 20, End: 29},
+			},
+			append: Interval{Start: 40, End: 49},
+			want: []Interval{
+				{Start: 0, End: 9},
+				{Start: 20, End: 29},
+				{Start: 40, End: 49},
+			},
+		},
+		"merge adjacent predecessor": {
+			intervals: []Interval{
+				{Start: 0, End: 9},
+				{Start: 20, End: 29},
+			},
+			append: Interval{Start: 10, End: 19},
+			want: []Interval{
+				{Start: 0, End: 29},
+			},
+		},
+		"merge overlapping successor": {
+			intervals: []Interval{
+				{Start: 20, End: 29},
+				{Start: 40, End: 49},
+			},
+			append: Interval{Start: 25, End: 45},
+			want: []Interval{
+				{Start: 20, End: 49},
+			},
+		},
+		"insert before first interval": {
+			intervals: []Interval{
+				{Start: 20, End: 29},
+				{Start: 40, End: 49},
+			},
+			append: Interval{Start: 0, End: 9},
+			want: []Interval{
+				{Start: 0, End: 9},
+				{Start: 20, End: 29},
+				{Start: 40, End: 49},
+			},
+		},
+	}
 
-		require.Equal(t, []Interval{
-			{Start: 0, End: 9},
-			{Start: 20, End: 29},
-			{Start: 40, End: 49},
-		}, got)
-	})
+	for name, tc := range testCases {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	t.Run("merge adjacent predecessor", func(t *testing.T) {
-		got := appendInterval([]Interval{
-			{Start: 0, End: 9},
-			{Start: 20, End: 29},
-		}, Interval{Start: 10, End: 19})
+			got := appendInterval(tc.intervals, tc.append)
 
-		require.Equal(t, []Interval{
-			{Start: 0, End: 29},
-		}, got)
-	})
-
-	t.Run("merge overlapping successor", func(t *testing.T) {
-		got := appendInterval([]Interval{
-			{Start: 20, End: 29},
-			{Start: 40, End: 49},
-		}, Interval{Start: 25, End: 45})
-
-		require.Equal(t, []Interval{
-			{Start: 20, End: 49},
-		}, got)
-	})
-
-	t.Run("insert before first interval", func(t *testing.T) {
-		got := appendInterval([]Interval{
-			{Start: 20, End: 29},
-			{Start: 40, End: 49},
-		}, Interval{Start: 0, End: 9})
-
-		require.Equal(t, []Interval{
-			{Start: 0, End: 9},
-			{Start: 20, End: 29},
-			{Start: 40, End: 49},
-		}, got)
-	})
+			require.Equal(t, tc.want, got)
+		})
+	}
 }
 
 // TestContainsCompletedInterval verifies that coverage checks succeed only when
@@ -253,29 +278,6 @@ func TestNewJournalInvalidJSON(t *testing.T) {
 
 	_, err = NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.Error(t, err)
-}
-
-// TestNewJournalReadsLegacyCompletedFilesOnRead verifies that the legacy
-// filename-set encoding is loaded and normalized into intervals.
-func TestNewJournalReadsLegacyCompletedFilesOnRead(t *testing.T) {
-	journalFile := filepath.Join(t.TempDir(), "journal.json")
-	raw := map[string]any{
-		"CompletedFiles": map[string]map[string]struct{}{
-			"testdata": {
-				"0-99999.gz":       {},
-				"100000-199999.gz": {},
-				"200000-299999.gz": {},
-			},
-		},
-	}
-	buf, err := json.Marshal(raw)
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(journalFile, buf, 0o644))
-
-	j, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
-	require.NoError(t, err)
-
-	require.Equal(t, completedIntervals(Interval{Start: 0, End: 299999}), j.CompletedFiles)
 }
 
 // TestNewJournalReadsIntervalCompletedFilesOnRead verifies that the new
@@ -357,21 +359,6 @@ func TestAddCompletedFilesDeduplicatesEquivalentRoots(t *testing.T) {
 	require.Equal(t, map[string][]Interval{"same-log": {{Start: 0, End: 9}}}, j.CompletedFiles)
 }
 
-// TestNewJournalRejectsMalformedCompletedFilesEncoding verifies that an
-// unsupported CompletedFiles JSON encoding is rejected.
-func TestNewJournalRejectsMalformedCompletedFilesEncoding(t *testing.T) {
-	journalFile := filepath.Join(t.TempDir(), "journal.json")
-	raw := map[string]any{
-		"CompletedFiles": []string{"bad-entry-without-slash"},
-	}
-	buf, err := json.Marshal(raw)
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(journalFile, buf, 0o644))
-
-	_, err = NewJournal(journalFile, testJobConfig(t, false), csvPath)
-	require.Error(t, err)
-}
-
 // TestNewJournalRejectsMalformedIntervalString verifies that reversed or
 // otherwise invalid interval strings are rejected on load.
 func TestNewJournalRejectsMalformedIntervalString(t *testing.T) {
@@ -387,55 +374,6 @@ func TestNewJournalRejectsMalformedIntervalString(t *testing.T) {
 
 	_, err = NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.Error(t, err)
-}
-
-// TestWritePersistsIntervalCompletedFilesJSON verifies that Write persists
-// CompletedFiles using the new interval-array JSON format.
-func TestWritePersistsIntervalCompletedFilesJSON(t *testing.T) {
-	journalFile := filepath.Join(t.TempDir(), "journal.json")
-	j, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
-	require.NoError(t, err)
-	require.NoError(t, j.AddCompletedFiles([]string{csvFiles[0], csvFiles[2]}))
-
-	buf, err := os.ReadFile(journalFile)
-	require.NoError(t, err)
-
-	var raw map[string]json.RawMessage
-	require.NoError(t, json.Unmarshal(buf, &raw))
-
-	var completed map[string][]string
-	require.NoError(t, json.Unmarshal(raw["CompletedFiles"], &completed))
-	require.Equal(t, map[string][]string{
-		"testdata": {"0-99999", "200000-299999"},
-	}, completed)
-}
-
-// TestWritePersistsJobsJSON verifies that job history is still written in the
-// dedicated Jobs field rather than flattened legacy fields.
-func TestWritePersistsJobsJSON(t *testing.T) {
-	journalFile := filepath.Join(t.TempDir(), "journal.json")
-	_, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
-	require.NoError(t, err)
-
-	buf, err := os.ReadFile(journalFile)
-	require.NoError(t, err)
-
-	var raw map[string]json.RawMessage
-	require.NoError(t, json.Unmarshal(buf, &raw))
-
-	var jobs []Job
-	require.NoError(t, json.Unmarshal(raw["Jobs"], &jobs))
-	require.Len(t, jobs, 1)
-	require.NotEmpty(t, jobs[0].Cwd)
-	require.NotEmpty(t, jobs[0].Cmd)
-	require.Equal(t, testJobConfig(t, false), jobs[0].JobConfiguration)
-
-	_, hasCwds := raw["Cwds"]
-	_, hasCmds := raw["Cmds"]
-	_, hasJobConfig := raw["JobConfiguration"]
-	require.False(t, hasCwds)
-	require.False(t, hasCmds)
-	require.False(t, hasJobConfig)
 }
 
 // TestClosePersistsAndIsIdempotent verifies that Close flushes state and can be

--- a/cmd/ingest/journal/journal_test.go
+++ b/cmd/ingest/journal/journal_test.go
@@ -301,41 +301,6 @@ func TestWritePersistsJobsJSON(t *testing.T) {
 	require.False(t, hasJobConfig)
 }
 
-func TestNewJournalReadsLegacyJobMetadataOnRead(t *testing.T) {
-	journalFile := filepath.Join(t.TempDir(), "journal.json")
-	cfg := testJobConfig(t)
-	raw := map[string]any{
-		"Cwds": []string{"/tmp/one", "/tmp/two"},
-		"Cmds": [][]string{
-			{"ingest", "--first"},
-			{"ingest", "--second"},
-		},
-		"JobConfiguration": cfg,
-		"CompletedFiles":   map[string]map[string]struct{}{},
-	}
-	buf, err := json.Marshal(raw)
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(journalFile, buf, 0o644))
-
-	j, err := NewJournal(journalFile, cfg, csvPath)
-	require.NoError(t, err)
-
-	require.Len(t, j.Jobs, 3)
-	require.Equal(t, Job{
-		Cwd:              "/tmp/one",
-		Cmd:              []string{"ingest", "--first"},
-		JobConfiguration: cfg,
-	}, j.Jobs[0])
-	require.Equal(t, Job{
-		Cwd:              "/tmp/two",
-		Cmd:              []string{"ingest", "--second"},
-		JobConfiguration: cfg,
-	}, j.Jobs[1])
-	require.NotEmpty(t, j.Jobs[2].Cwd)
-	require.NotEmpty(t, j.Jobs[2].Cmd)
-	require.Equal(t, cfg, j.Jobs[2].JobConfiguration)
-}
-
 func TestClosePersistsAndIsIdempotent(t *testing.T) {
 	journalFile := filepath.Join(t.TempDir(), "journal.json")
 	j, err := NewJournal(journalFile, testJobConfig(t), csvPath)

--- a/cmd/ingest/journal/journal_test.go
+++ b/cmd/ingest/journal/journal_test.go
@@ -275,6 +275,67 @@ func TestWritePersistsNestedCompletedFilesJSON(t *testing.T) {
 	require.Equal(t, normalizedCSVSet(0, 2), completed)
 }
 
+func TestWritePersistsJobsJSON(t *testing.T) {
+	journalFile := filepath.Join(t.TempDir(), "journal.json")
+	_, err := NewJournal(journalFile, testJobConfig(t), csvPath)
+	require.NoError(t, err)
+
+	buf, err := os.ReadFile(journalFile)
+	require.NoError(t, err)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(buf, &raw))
+
+	var jobs []Job
+	require.NoError(t, json.Unmarshal(raw["Jobs"], &jobs))
+	require.Len(t, jobs, 1)
+	require.NotEmpty(t, jobs[0].Cwd)
+	require.NotEmpty(t, jobs[0].Cmd)
+	require.Equal(t, testJobConfig(t), jobs[0].JobConfiguration)
+
+	_, hasCwds := raw["Cwds"]
+	_, hasCmds := raw["Cmds"]
+	_, hasJobConfig := raw["JobConfiguration"]
+	require.False(t, hasCwds)
+	require.False(t, hasCmds)
+	require.False(t, hasJobConfig)
+}
+
+func TestNewJournalReadsLegacyJobMetadataOnRead(t *testing.T) {
+	journalFile := filepath.Join(t.TempDir(), "journal.json")
+	cfg := testJobConfig(t)
+	raw := map[string]any{
+		"Cwds": []string{"/tmp/one", "/tmp/two"},
+		"Cmds": [][]string{
+			{"ingest", "--first"},
+			{"ingest", "--second"},
+		},
+		"JobConfiguration": cfg,
+		"CompletedFiles":   map[string]map[string]struct{}{},
+	}
+	buf, err := json.Marshal(raw)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(journalFile, buf, 0o644))
+
+	j, err := NewJournal(journalFile, cfg, csvPath)
+	require.NoError(t, err)
+
+	require.Len(t, j.Jobs, 3)
+	require.Equal(t, Job{
+		Cwd:              "/tmp/one",
+		Cmd:              []string{"ingest", "--first"},
+		JobConfiguration: cfg,
+	}, j.Jobs[0])
+	require.Equal(t, Job{
+		Cwd:              "/tmp/two",
+		Cmd:              []string{"ingest", "--second"},
+		JobConfiguration: cfg,
+	}, j.Jobs[1])
+	require.NotEmpty(t, j.Jobs[2].Cwd)
+	require.NotEmpty(t, j.Jobs[2].Cmd)
+	require.Equal(t, cfg, j.Jobs[2].JobConfiguration)
+}
+
 func TestClosePersistsAndIsIdempotent(t *testing.T) {
 	journalFile := filepath.Join(t.TempDir(), "journal.json")
 	j, err := NewJournal(journalFile, testJobConfig(t), csvPath)

--- a/cmd/ingest/journal/list_files.go
+++ b/cmd/ingest/journal/list_files.go
@@ -8,7 +8,8 @@ import (
 	"github.com/netsec-ethz/fpki/pkg/util"
 )
 
-// ListCsvFiles returns the .gz and .csv files sorted by name.
+// ListCsvFiles returns the discovered `.gz` and `.csv` files separately,
+// leaving higher layers to decide which sets to include in a given run.
 func ListCsvFiles(dir string) (gzFiles, csvFiles []string, err error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -149,7 +149,7 @@ func mainFunction() error {
 	})
 
 	err = runIngest(ctx, cfg, RunDependencies{
-		NewJournal: func(cfg RunConfig, jobCfg journal.JobConfiguration) (JournalStore, error) {
+		NewJournal: func(cfg RunConfig, jobCfg journal.JobConfiguration) (*journal.Journal, error) {
 			return journal.NewJournal(cfg.JournalFile, jobCfg, cfg.Directory)
 		},
 		NewStatistics: func() *updater.Stats {

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -258,6 +258,7 @@ func configFromFlags() RunConfig {
 		NumParsers:       *args.NumParsers,
 		NumChainToCerts:  *args.NumChainToCerts,
 		NumDBWriters:     *args.NumDBWriters,
+		IncludePlainCSVs: *args.IncludePlainCSVs,
 		SkipMissingFiles: *args.SkipMissingFiles,
 		CpuProfile:       *args.CpuProfile,
 		MemProfile:       *args.MemProfile,
@@ -498,7 +499,7 @@ func writeMetaFile(path string, meta diagnosticsMeta) error {
 	_, err = fmt.Fprintf(f,
 		"timestamp=%s\nprocess_start=%s\nuptime=%s\nuptime_seconds=%f\nsignal=%s\npid=%d\nargs=%q\n"+
 			"strategy=%s\nfilebatch=%d\nmultiinsert=%d\nnumfiles=%d\nnumparsers=%d\nnumdechainers=%d\n"+
-			"numdbworkers=%d\ndirectory=%s\njournal=%s\n",
+			"numdbworkers=%d\nincludeplaincsvs=%t\ndirectory=%s\njournal=%s\n",
 		meta.Time.Format(time.RFC3339Nano),
 		meta.ProcessStart.Format(time.RFC3339Nano),
 		meta.Uptime,
@@ -513,6 +514,7 @@ func writeMetaFile(path string, meta diagnosticsMeta) error {
 		meta.Config.NumParsers,
 		meta.Config.NumChainToCerts,
 		meta.Config.NumDBWriters,
+		meta.Config.IncludePlainCSVs,
 		meta.Config.Directory,
 		meta.Config.JournalFile,
 	)

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -148,7 +148,7 @@ func mainFunction() error {
 		exit:              util.Exit,
 	})
 
-	err = runIngestContext(ctx, cfg, RunDependencies{
+	err = runIngest(ctx, cfg, RunDependencies{
 		NewJournal: func(cfg RunConfig, jobCfg journal.JobConfiguration) (JournalStore, error) {
 			return journal.NewJournal(cfg.JournalFile, jobCfg, cfg.Directory)
 		},

--- a/cmd/ingest/run.go
+++ b/cmd/ingest/run.go
@@ -33,7 +33,7 @@ type RunConfig struct {
 
 type JournalStore interface {
 	PendingFiles() ([]string, error)
-	AddCompletedFiles([]string) error
+	CommitProgress(files []string, coalesced bool, updatedSMT bool) error
 	Close() error
 }
 
@@ -108,12 +108,18 @@ func runIngestContext(ctx context.Context, cfg RunConfig, deps RunDependencies) 
 			if err := coalesce(); err != nil {
 				return err
 			}
+			if err := j.CommitProgress(nil, true, false); err != nil {
+				return err
+			}
 		}
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 		if jobCfg.UpdateSMT {
 			if err := updateSMT(); err != nil {
+				return err
+			}
+			if err := j.CommitProgress(nil, jobCfg.Coalesce, true); err != nil {
 				return err
 			}
 		}
@@ -153,7 +159,7 @@ func runIngestContext(ctx context.Context, cfg RunConfig, deps RunDependencies) 
 					return err
 				}
 			}
-			return j.AddCompletedFiles(files)
+			return j.CommitProgress(files, jobCfg.Coalesce, jobCfg.UpdateSMT)
 		},
 	)
 }

--- a/cmd/ingest/run.go
+++ b/cmd/ingest/run.go
@@ -63,14 +63,7 @@ func (cfg RunConfig) validate() error {
 	return nil
 }
 
-func runIngest(cfg RunConfig, deps RunDependencies) error {
-	if err := cfg.validate(); err != nil {
-		return err
-	}
-	return runIngestContext(context.Background(), cfg, deps)
-}
-
-func runIngestContext(ctx context.Context, cfg RunConfig, deps RunDependencies) error {
+func runIngest(ctx context.Context, cfg RunConfig, deps RunDependencies) error {
 	if err := cfg.validate(); err != nil {
 		return err
 	}

--- a/cmd/ingest/run.go
+++ b/cmd/ingest/run.go
@@ -31,15 +31,9 @@ type RunConfig struct {
 	MemProfile       string
 }
 
-type JournalStore interface {
-	PendingFiles() ([]string, error)
-	CommitProgress(files []string, coalesced bool, updatedSMT bool) error
-	Close() error
-}
-
 // RunDependencies collects all necessary functions to effectively run ingest.
 type RunDependencies struct {
-	NewJournal        func(RunConfig, journal.JobConfiguration) (JournalStore, error)
+	NewJournal        func(RunConfig, journal.JobConfiguration) (*journal.Journal, error)
 	NewStatistics     func() *updater.Stats
 	EstimateCertCount func(string) (uint, error)
 	BeforeBatch       func(batchNum, batchCount int) error
@@ -159,7 +153,7 @@ func runIngest(ctx context.Context, cfg RunConfig, deps RunDependencies) error {
 
 func ingestFilesInBatches(
 	ctx context.Context,
-	j JournalStore,
+	j *journal.Journal,
 	stats *updater.Stats,
 	fileBatchSize int,
 	estimateCertCount func(string) (uint, error),

--- a/cmd/ingest/run.go
+++ b/cmd/ingest/run.go
@@ -14,15 +14,18 @@ import (
 )
 
 type RunConfig struct {
-	Directory        string
-	Strategy         string
-	JournalFile      string
-	FileBatch        int
-	MultiInsertSize  int
-	NumFiles         int
-	NumParsers       int
-	NumChainToCerts  int
-	NumDBWriters     int
+	Directory       string
+	Strategy        string
+	JournalFile     string
+	FileBatch       int
+	MultiInsertSize int
+	NumFiles        int
+	NumParsers      int
+	NumChainToCerts int
+	NumDBWriters    int
+	// IncludePlainCSVs controls whether pending-file discovery includes plain
+	// `.csv` bundles or restricts processing to compressed `.gz` bundles only.
+	IncludePlainCSVs bool
 	SkipMissingFiles bool
 	CpuProfile       string
 	MemProfile       string
@@ -46,7 +49,7 @@ type RunDependencies struct {
 }
 
 func (cfg RunConfig) JobConfiguration() (journal.JobConfiguration, error) {
-	return journal.NewJobConfiguration(cfg.Strategy, cfg.FileBatch)
+	return journal.NewJobConfiguration(cfg.Strategy, cfg.FileBatch, cfg.IncludePlainCSVs)
 }
 
 func (cfg RunConfig) validate() error {

--- a/cmd/ingest/run_test.go
+++ b/cmd/ingest/run_test.go
@@ -29,13 +29,9 @@ func TestRunIngestFreshJournalPersistsProgress(t *testing.T) {
 	require.Zero(t, updateCount)
 
 	j := loadJournalForTest(t, cfg)
-	require.Equal(t, map[string]map[string]struct{}{
-		ingestTestBase: {
-			"0-9.gz":   {},
-			"10-19.gz": {},
-			"20-29.gz": {},
-		},
-	}, j.CompletedFiles)
+	require.Equal(t, completedIngestTestIntervals(
+		journal.Interval{Start: 0, End: 29},
+	), j.CompletedFiles)
 	pending, err := j.PendingFiles()
 	require.NoError(t, err)
 	require.Empty(t, pending)
@@ -56,13 +52,9 @@ func TestRunIngestResumesFromExistingJournal(t *testing.T) {
 	require.Equal(t, [][]string{{files[1]}, {files[2]}}, runOrder)
 
 	j = loadJournalForTest(t, cfg)
-	require.Equal(t, map[string]map[string]struct{}{
-		ingestTestBase: {
-			"0-9.gz":   {},
-			"10-19.gz": {},
-			"20-29.gz": {},
-		},
-	}, j.CompletedFiles)
+	require.Equal(t, completedIngestTestIntervals(
+		journal.Interval{Start: 0, End: 29},
+	), j.CompletedFiles)
 }
 
 func TestRunIngestSkipsWhenAlreadyComplete(t *testing.T) {
@@ -103,11 +95,9 @@ func TestRunIngestFailedBatchDoesNotAdvanceJournal(t *testing.T) {
 	require.Equal(t, 1, updateCount)
 
 	j := loadJournalForTest(t, cfg)
-	require.Equal(t, map[string]map[string]struct{}{
-		ingestTestBase: {
-			"0-9.gz": {},
-		},
-	}, j.CompletedFiles)
+	require.Equal(t, completedIngestTestIntervals(
+		journal.Interval{Start: 0, End: 9},
+	), j.CompletedFiles)
 	pending, err := j.PendingFiles()
 	require.NoError(t, err)
 	require.Equal(t, files[1:], pending)
@@ -260,4 +250,10 @@ func loadJournalForTest(t *testing.T, cfg RunConfig) *journal.Journal {
 	j, err := journal.NewJournal(cfg.JournalFile, jobCfg, cfg.Directory)
 	require.NoError(t, err)
 	return j
+}
+
+func completedIngestTestIntervals(intervals ...journal.Interval) map[string][]journal.Interval {
+	return map[string][]journal.Interval{
+		ingestTestBase: intervals,
+	}
 }

--- a/cmd/ingest/run_test.go
+++ b/cmd/ingest/run_test.go
@@ -15,163 +15,204 @@ import (
 
 const ingestTestBase = "fpki-ingest-test"
 
-func TestRunIngestFreshJournalPersistsProgress(t *testing.T) {
-	dir, files := makeIngestTestFiles(t)
-	cfg := newTestRunConfig(dir, filepath.Join(t.TempDir(), "journal.json"), 0, "onlyingest")
-
-	var runOrder [][]string
-	var coalesceCount, updateCount int
-	err := runIngest(cfg, newTestDeps(t, &runOrder, &coalesceCount, &updateCount, 0))
-	require.NoError(t, err)
-
-	require.Equal(t, [][]string{files}, runOrder)
-	require.Zero(t, coalesceCount)
-	require.Zero(t, updateCount)
-
-	j := loadJournalForTest(t, cfg)
-	require.Equal(t, completedIngestTestIntervals(
-		journal.Interval{Start: 0, End: 29},
-	), latestJobForTest(t, j).CompletedIndices)
-	pending, err := j.PendingFiles()
-	require.NoError(t, err)
-	require.Empty(t, pending)
-}
-
-func TestRunIngestResumesFromExistingJournal(t *testing.T) {
-	dir, files := makeIngestTestFiles(t)
-	cfg := newTestRunConfig(dir, filepath.Join(t.TempDir(), "journal.json"), 1, "onlyingest")
-
-	j := loadJournalForTest(t, cfg)
-	require.NoError(t, j.CommitProgress(files[:1], false, false))
-
-	var runOrder [][]string
-	var coalesceCount, updateCount int
-	err := runIngest(cfg, newTestDeps(t, &runOrder, &coalesceCount, &updateCount, 0))
-	require.NoError(t, err)
-
-	require.Equal(t, [][]string{{files[1]}, {files[2]}}, runOrder)
-
-	j = loadJournalForTest(t, cfg)
-	require.Equal(t, completedIngestTestIntervals(
-		journal.Interval{Start: 0, End: 29},
-	), latestJobForTest(t, j).CompletedIndices)
-}
-
-func TestRunIngestSkipsWhenAlreadyComplete(t *testing.T) {
-	dir, files := makeIngestTestFiles(t)
-	cfg := newTestRunConfig(dir, filepath.Join(t.TempDir(), "journal.json"), 2, "onlyingest")
-
-	j := loadJournalForTest(t, cfg)
-	require.NoError(t, j.CommitProgress(files, false, false))
-
-	var runOrder [][]string
-	var coalesceCount, updateCount int
-	err := runIngest(cfg, newTestDeps(t, &runOrder, &coalesceCount, &updateCount, 0))
-	require.NoError(t, err)
-	require.Empty(t, runOrder)
-}
-
-func TestRunIngestBatchingOrder(t *testing.T) {
-	dir, files := makeIngestTestFiles(t)
-	cfg := newTestRunConfig(dir, filepath.Join(t.TempDir(), "journal.json"), 2, "onlyingest")
-
-	var runOrder [][]string
-	var coalesceCount, updateCount int
-	err := runIngest(cfg, newTestDeps(t, &runOrder, &coalesceCount, &updateCount, 0))
-	require.NoError(t, err)
-	require.Equal(t, [][]string{{files[0], files[1]}, {files[2]}}, runOrder)
-}
-
-func TestRunIngestFailedBatchDoesNotAdvanceJournal(t *testing.T) {
-	dir, files := makeIngestTestFiles(t)
-	cfg := newTestRunConfig(dir, filepath.Join(t.TempDir(), "journal.json"), 1, "")
-
-	var runOrder [][]string
-	var coalesceCount, updateCount int
-	err := runIngest(cfg, newTestDeps(t, &runOrder, &coalesceCount, &updateCount, 2))
-	require.Error(t, err)
-	require.Len(t, runOrder, 2)
-	require.Equal(t, 1, coalesceCount)
-	require.Equal(t, 1, updateCount)
-
-	j := loadJournalForTest(t, cfg)
-	require.Equal(t, completedIngestTestIntervals(
-		journal.Interval{Start: 0, End: 9},
-	), latestJobForTest(t, j).CompletedIndices)
-	require.True(t, previousJobForTest(t, j).Coalesced)
-	require.True(t, previousJobForTest(t, j).UpdatedSMT)
-	pending, err := j.PendingFiles()
-	require.NoError(t, err)
-	require.Equal(t, files[1:], pending)
-}
-
-func TestRunIngestInvalidJournalFileReturnsError(t *testing.T) {
-	dir, _ := makeIngestTestFiles(t)
-	journalFile := filepath.Join(t.TempDir(), "journal.json")
-	require.NoError(t, os.WriteFile(journalFile, []byte("{"), 0o644))
-	cfg := newTestRunConfig(dir, journalFile, 1, "onlyingest")
-
-	var runOrder [][]string
-	var coalesceCount, updateCount int
-	err := runIngest(cfg, newTestDeps(t, &runOrder, &coalesceCount, &updateCount, 0))
-	require.Error(t, err)
-}
-
-func TestRunIngestMissingDirectoryReturnsError(t *testing.T) {
-	cfg := newTestRunConfig(
-		filepath.Join(t.TempDir(), "does-not-exist"),
-		filepath.Join(t.TempDir(), "journal.json"),
-		1,
-		"onlyingest",
-	)
-
-	var runOrder [][]string
-	var coalesceCount, updateCount int
-	err := runIngest(cfg, newTestDeps(t, &runOrder, &coalesceCount, &updateCount, 0))
-	require.Error(t, err)
-	require.ErrorIs(t, err, os.ErrNotExist)
-	require.Empty(t, runOrder)
-}
-
-func TestRunIngestContextCancelledBeforeBatch(t *testing.T) {
-	dir, _ := makeIngestTestFiles(t)
-	cfg := newTestRunConfig(dir, filepath.Join(t.TempDir(), "journal.json"), 1, "onlyingest")
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	var runOrder [][]string
-	var coalesceCount, updateCount int
-	err := runIngestContext(ctx, cfg, newTestDeps(t, &runOrder, &coalesceCount, &updateCount, 0))
-	require.ErrorIs(t, err, context.Canceled)
-	require.Empty(t, runOrder)
-}
-
-func TestRunIngestStrategyMatrix(t *testing.T) {
-	testCases := map[string]struct {
-		strategy      string
-		wantBatches   int
-		wantCoalesce  int
-		wantSMTUpdate int
+func TestRunIngestScenarios(t *testing.T) {
+	runIngestCases := map[string]struct {
+		fileBatch       int
+		strategy        string
+		failBatch       int
+		missingDir      bool
+		makeContext     func(*testing.T) context.Context
+		prepare         func(*testing.T, RunConfig, []string)
+		check           func(*testing.T, RunConfig, []string, error, [][]string, int, int)
 	}{
-		"onlyingest":    {strategy: "onlyingest", wantBatches: 1},
-		"default":       {strategy: "", wantBatches: 1, wantCoalesce: 1, wantSMTUpdate: 1},
-		"skipingest":    {strategy: "skipingest", wantCoalesce: 1, wantSMTUpdate: 1},
-		"onlysmtupdate": {strategy: "onlysmtupdate", wantSMTUpdate: 1},
+		// Starts from an empty journal and persists the full ingest interval in one run.
+		"fresh_journal_persists_progress": {
+			fileBatch: 0,
+			strategy:  "onlyingest",
+			check: func(t *testing.T, cfg RunConfig, files []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+				require.NoError(t, err)
+				require.Equal(t, [][]string{files}, runOrder)
+				require.Zero(t, coalesceCount)
+				require.Zero(t, updateCount)
+
+				j := loadJournalForTest(t, cfg)
+				require.Equal(t, completedIngestTestIntervals(
+					journal.Interval{Start: 0, End: 29},
+				), latestJobForTest(t, j).CompletedIndices)
+				pending, err := j.PendingFiles()
+				require.NoError(t, err)
+				require.Empty(t, pending)
+			},
+		},
+		// Reuses the previous completed snapshot so only uncovered files are ingested.
+		"resume_from_existing_journal": {
+			fileBatch: 1,
+			strategy:  "onlyingest",
+			prepare: func(t *testing.T, cfg RunConfig, files []string) {
+				j := loadJournalForTest(t, cfg)
+				require.NoError(t, j.CommitProgress(files[:1], false, false))
+			},
+			check: func(t *testing.T, cfg RunConfig, files []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+				require.NoError(t, err)
+				require.Equal(t, [][]string{{files[1]}, {files[2]}}, runOrder)
+				require.Zero(t, coalesceCount)
+				require.Zero(t, updateCount)
+
+				j := loadJournalForTest(t, cfg)
+				require.Equal(t, completedIngestTestIntervals(
+					journal.Interval{Start: 0, End: 29},
+				), latestJobForTest(t, j).CompletedIndices)
+			},
+		},
+		// Detects a fully completed snapshot and skips ingest work entirely.
+		"skip_when_already_complete": {
+			fileBatch: 2,
+			strategy:  "onlyingest",
+			prepare: func(t *testing.T, cfg RunConfig, files []string) {
+				j := loadJournalForTest(t, cfg)
+				require.NoError(t, j.CommitProgress(files, false, false))
+			},
+			check: func(t *testing.T, _ RunConfig, _ []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+				require.NoError(t, err)
+				require.Empty(t, runOrder)
+				require.Zero(t, coalesceCount)
+				require.Zero(t, updateCount)
+			},
+		},
+		// Splits ingest work into batches while preserving the discovered file order.
+		"batching_respects_file_order": {
+			fileBatch: 2,
+			strategy:  "onlyingest",
+			check: func(t *testing.T, _ RunConfig, files []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+				require.NoError(t, err)
+				require.Equal(t, [][]string{{files[0], files[1]}, {files[2]}}, runOrder)
+				require.Zero(t, coalesceCount)
+				require.Zero(t, updateCount)
+			},
+		},
+		// Leaves the journal at the last successful batch when a later batch fails after coalesce and SMT.
+		"failed_second_batch_keeps_last_successful_progress": {
+			fileBatch: 1,
+			strategy:  "",
+			failBatch: 2,
+			check: func(t *testing.T, cfg RunConfig, files []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+				require.Error(t, err)
+				require.Len(t, runOrder, 2)
+				require.Equal(t, 1, coalesceCount)
+				require.Equal(t, 1, updateCount)
+
+				j := loadJournalForTest(t, cfg)
+				require.Equal(t, completedIngestTestIntervals(
+					journal.Interval{Start: 0, End: 9},
+				), latestJobForTest(t, j).CompletedIndices)
+				require.True(t, previousJobForTest(t, j).Coalesced)
+				require.True(t, previousJobForTest(t, j).UpdatedSMT)
+				pending, pendingErr := j.PendingFiles()
+				require.NoError(t, pendingErr)
+				require.Equal(t, files[1:], pending)
+			},
+		},
+		// Rejects malformed persisted state before any ingest work starts.
+		"invalid_journal_file_returns_error": {
+			fileBatch: 1,
+			strategy:  "onlyingest",
+			prepare: func(t *testing.T, cfg RunConfig, _ []string) {
+				require.NoError(t, os.WriteFile(cfg.JournalFile, []byte("{"), 0o644))
+			},
+			check: func(t *testing.T, _ RunConfig, _ []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+				require.Error(t, err)
+				require.Empty(t, runOrder)
+				require.Zero(t, coalesceCount)
+				require.Zero(t, updateCount)
+			},
+		},
+		// Surfaces missing ingest directories as filesystem errors without running any batches.
+		"missing_directory_returns_error": {
+			fileBatch:  1,
+			strategy:   "onlyingest",
+			missingDir: true,
+			check: func(t *testing.T, _ RunConfig, _ []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+				require.Error(t, err)
+				require.ErrorIs(t, err, os.ErrNotExist)
+				require.Empty(t, runOrder)
+				require.Zero(t, coalesceCount)
+				require.Zero(t, updateCount)
+			},
+		},
+		// Returns early when the caller-provided context is already canceled before any batch starts.
+		"context_canceled_before_batch": {
+			fileBatch: 1,
+			strategy:  "onlyingest",
+			makeContext: func(t *testing.T) context.Context {
+				t.Helper()
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			check: func(t *testing.T, _ RunConfig, _ []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+				require.ErrorIs(t, err, context.Canceled)
+				require.Empty(t, runOrder)
+				require.Zero(t, coalesceCount)
+				require.Zero(t, updateCount)
+			},
+		},
+		// Runs the default strategy through ingest, coalesce, and SMT update in one pass.
+		"default_strategy_runs_all_phases": {
+			fileBatch: 0,
+			strategy:  "",
+			check: func(t *testing.T, _ RunConfig, _ []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+				require.NoError(t, err)
+				require.Len(t, runOrder, 1)
+				require.Equal(t, 1, coalesceCount)
+				require.Equal(t, 1, updateCount)
+			},
+		},
+		// Skips file ingestion and runs only coalesce plus SMT update on the carried-forward snapshot.
+		"skipingest_strategy_runs_followup_phases_only": {
+			fileBatch: 0,
+			strategy:  "skipingest",
+			check: func(t *testing.T, _ RunConfig, _ []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+				require.NoError(t, err)
+				require.Empty(t, runOrder)
+				require.Equal(t, 1, coalesceCount)
+				require.Equal(t, 1, updateCount)
+			},
+		},
+		// Runs only the SMT update phase when requested explicitly.
+		"onlysmtupdate_strategy_runs_smt_only": {
+			fileBatch: 0,
+			strategy:  "onlysmtupdate",
+			check: func(t *testing.T, _ RunConfig, _ []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+				require.NoError(t, err)
+				require.Empty(t, runOrder)
+				require.Zero(t, coalesceCount)
+				require.Equal(t, 1, updateCount)
+			},
+		},
 	}
 
-	for name, tc := range testCases {
+	for name, tc := range runIngestCases {
 		t.Run(name, func(t *testing.T) {
-			dir, _ := makeIngestTestFiles(t)
-			cfg := newTestRunConfig(dir, filepath.Join(t.TempDir(), "journal.json"), 0, tc.strategy)
+			dir, files := makeIngestTestFiles(t)
+			if tc.missingDir {
+				dir = filepath.Join(t.TempDir(), "does-not-exist")
+			}
+
+			cfg := newTestRunConfig(dir, filepath.Join(t.TempDir(), "journal.json"), tc.fileBatch, tc.strategy)
+			if tc.prepare != nil {
+				tc.prepare(t, cfg, files)
+			}
+
+			ctx := context.Background()
+			if tc.makeContext != nil {
+				ctx = tc.makeContext(t)
+			}
 
 			var runOrder [][]string
 			var coalesceCount, updateCount int
-			err := runIngest(cfg, newTestDeps(t, &runOrder, &coalesceCount, &updateCount, 0))
-			require.NoError(t, err)
-			require.Len(t, runOrder, tc.wantBatches)
-			require.Equal(t, tc.wantCoalesce, coalesceCount)
-			require.Equal(t, tc.wantSMTUpdate, updateCount)
+			err := runIngest(ctx, cfg, newTestDeps(t, &runOrder, &coalesceCount, &updateCount, tc.failBatch))
+
+			tc.check(t, cfg, files, err, runOrder, coalesceCount, updateCount)
 		})
 	}
 }

--- a/cmd/ingest/run_test.go
+++ b/cmd/ingest/run_test.go
@@ -31,7 +31,7 @@ func TestRunIngestFreshJournalPersistsProgress(t *testing.T) {
 	j := loadJournalForTest(t, cfg)
 	require.Equal(t, completedIngestTestIntervals(
 		journal.Interval{Start: 0, End: 29},
-	), j.CompletedFiles)
+	), latestJobForTest(t, j).CompletedIndices)
 	pending, err := j.PendingFiles()
 	require.NoError(t, err)
 	require.Empty(t, pending)
@@ -42,7 +42,7 @@ func TestRunIngestResumesFromExistingJournal(t *testing.T) {
 	cfg := newTestRunConfig(dir, filepath.Join(t.TempDir(), "journal.json"), 1, "onlyingest")
 
 	j := loadJournalForTest(t, cfg)
-	require.NoError(t, j.AddCompletedFiles(files[:1]))
+	require.NoError(t, j.CommitProgress(files[:1], false, false))
 
 	var runOrder [][]string
 	var coalesceCount, updateCount int
@@ -54,7 +54,7 @@ func TestRunIngestResumesFromExistingJournal(t *testing.T) {
 	j = loadJournalForTest(t, cfg)
 	require.Equal(t, completedIngestTestIntervals(
 		journal.Interval{Start: 0, End: 29},
-	), j.CompletedFiles)
+	), latestJobForTest(t, j).CompletedIndices)
 }
 
 func TestRunIngestSkipsWhenAlreadyComplete(t *testing.T) {
@@ -62,7 +62,7 @@ func TestRunIngestSkipsWhenAlreadyComplete(t *testing.T) {
 	cfg := newTestRunConfig(dir, filepath.Join(t.TempDir(), "journal.json"), 2, "onlyingest")
 
 	j := loadJournalForTest(t, cfg)
-	require.NoError(t, j.AddCompletedFiles(files))
+	require.NoError(t, j.CommitProgress(files, false, false))
 
 	var runOrder [][]string
 	var coalesceCount, updateCount int
@@ -97,7 +97,9 @@ func TestRunIngestFailedBatchDoesNotAdvanceJournal(t *testing.T) {
 	j := loadJournalForTest(t, cfg)
 	require.Equal(t, completedIngestTestIntervals(
 		journal.Interval{Start: 0, End: 9},
-	), j.CompletedFiles)
+	), latestJobForTest(t, j).CompletedIndices)
+	require.True(t, previousJobForTest(t, j).Coalesced)
+	require.True(t, previousJobForTest(t, j).UpdatedSMT)
 	pending, err := j.PendingFiles()
 	require.NoError(t, err)
 	require.Equal(t, files[1:], pending)
@@ -256,4 +258,16 @@ func completedIngestTestIntervals(intervals ...journal.Interval) map[string][]jo
 	return map[string][]journal.Interval{
 		ingestTestBase: intervals,
 	}
+}
+
+func latestJobForTest(t *testing.T, j *journal.Journal) journal.Job {
+	t.Helper()
+	require.NotEmpty(t, j.Jobs)
+	return j.Jobs[len(j.Jobs)-1]
+}
+
+func previousJobForTest(t *testing.T, j *journal.Journal) journal.Job {
+	t.Helper()
+	require.GreaterOrEqual(t, len(j.Jobs), 2)
+	return j.Jobs[len(j.Jobs)-2]
 }

--- a/cmd/ingest/run_test.go
+++ b/cmd/ingest/run_test.go
@@ -17,19 +17,37 @@ const ingestTestBase = "fpki-ingest-test"
 
 func TestRunIngestScenarios(t *testing.T) {
 	runIngestCases := map[string]struct {
-		fileBatch       int
-		strategy        string
-		failBatch       int
-		missingDir      bool
-		makeContext     func(*testing.T) context.Context
-		prepare         func(*testing.T, RunConfig, []string)
-		check           func(*testing.T, RunConfig, []string, error, [][]string, int, int)
+		// fileBatch controls the configured ingest batch size for the scenario.
+		fileBatch int
+		// strategy selects which ingest/coalesce/SMT phases the run should execute.
+		strategy string
+		// failBatch injects a forced RunBatch failure on the Nth batch.
+		// Zero means no failure.
+		failBatch int
+		// missingDir swaps the generated ingest root for a path that does not exist.
+		missingDir bool
+		// makeContext optionally provides a custom context.
+		// When nil the runner uses context.Background().
+		makeContext func(*testing.T) context.Context
+		// prepare mutates the test setup before runIngest is called.
+		prepare func(*testing.T, RunConfig, []string)
+		// check asserts the outcome using the run config, ingest files,
+		// error, batch order, and phase counts.
+		check func(*testing.T, RunConfig, []string, error, [][]string, int, int)
 	}{
 		// Starts from an empty journal and persists the full ingest interval in one run.
 		"fresh_journal_persists_progress": {
 			fileBatch: 0,
 			strategy:  "onlyingest",
-			check: func(t *testing.T, cfg RunConfig, files []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+			check: func(
+				t *testing.T,
+				cfg RunConfig,
+				files []string,
+				err error,
+				runOrder [][]string,
+				coalesceCount int,
+				updateCount int,
+			) {
 				require.NoError(t, err)
 				require.Equal(t, [][]string{files}, runOrder)
 				require.Zero(t, coalesceCount)
@@ -52,7 +70,15 @@ func TestRunIngestScenarios(t *testing.T) {
 				j := loadJournalForTest(t, cfg)
 				require.NoError(t, j.CommitProgress(files[:1], false, false))
 			},
-			check: func(t *testing.T, cfg RunConfig, files []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+			check: func(
+				t *testing.T,
+				cfg RunConfig,
+				files []string,
+				err error,
+				runOrder [][]string,
+				coalesceCount int,
+				updateCount int,
+			) {
 				require.NoError(t, err)
 				require.Equal(t, [][]string{{files[1]}, {files[2]}}, runOrder)
 				require.Zero(t, coalesceCount)
@@ -72,7 +98,15 @@ func TestRunIngestScenarios(t *testing.T) {
 				j := loadJournalForTest(t, cfg)
 				require.NoError(t, j.CommitProgress(files, false, false))
 			},
-			check: func(t *testing.T, _ RunConfig, _ []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+			check: func(
+				t *testing.T,
+				_ RunConfig,
+				_ []string,
+				err error,
+				runOrder [][]string,
+				coalesceCount int,
+				updateCount int,
+			) {
 				require.NoError(t, err)
 				require.Empty(t, runOrder)
 				require.Zero(t, coalesceCount)
@@ -83,19 +117,36 @@ func TestRunIngestScenarios(t *testing.T) {
 		"batching_respects_file_order": {
 			fileBatch: 2,
 			strategy:  "onlyingest",
-			check: func(t *testing.T, _ RunConfig, files []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+			check: func(
+				t *testing.T,
+				_ RunConfig,
+				files []string,
+				err error,
+				runOrder [][]string,
+				coalesceCount int,
+				updateCount int,
+			) {
 				require.NoError(t, err)
 				require.Equal(t, [][]string{{files[0], files[1]}, {files[2]}}, runOrder)
 				require.Zero(t, coalesceCount)
 				require.Zero(t, updateCount)
 			},
 		},
-		// Leaves the journal at the last successful batch when a later batch fails after coalesce and SMT.
+		// Leaves the journal at the last successful batch when a later batch
+		// fails after coalesce and SMT.
 		"failed_second_batch_keeps_last_successful_progress": {
 			fileBatch: 1,
 			strategy:  "",
 			failBatch: 2,
-			check: func(t *testing.T, cfg RunConfig, files []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+			check: func(
+				t *testing.T,
+				cfg RunConfig,
+				files []string,
+				err error,
+				runOrder [][]string,
+				coalesceCount int,
+				updateCount int,
+			) {
 				require.Error(t, err)
 				require.Len(t, runOrder, 2)
 				require.Equal(t, 1, coalesceCount)
@@ -119,19 +170,36 @@ func TestRunIngestScenarios(t *testing.T) {
 			prepare: func(t *testing.T, cfg RunConfig, _ []string) {
 				require.NoError(t, os.WriteFile(cfg.JournalFile, []byte("{"), 0o644))
 			},
-			check: func(t *testing.T, _ RunConfig, _ []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+			check: func(
+				t *testing.T,
+				_ RunConfig,
+				_ []string,
+				err error,
+				runOrder [][]string,
+				coalesceCount int,
+				updateCount int,
+			) {
 				require.Error(t, err)
 				require.Empty(t, runOrder)
 				require.Zero(t, coalesceCount)
 				require.Zero(t, updateCount)
 			},
 		},
-		// Surfaces missing ingest directories as filesystem errors without running any batches.
+		// Surfaces missing ingest directories as filesystem errors without
+		// running any batches.
 		"missing_directory_returns_error": {
 			fileBatch:  1,
 			strategy:   "onlyingest",
 			missingDir: true,
-			check: func(t *testing.T, _ RunConfig, _ []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+			check: func(
+				t *testing.T,
+				_ RunConfig,
+				_ []string,
+				err error,
+				runOrder [][]string,
+				coalesceCount int,
+				updateCount int,
+			) {
 				require.Error(t, err)
 				require.ErrorIs(t, err, os.ErrNotExist)
 				require.Empty(t, runOrder)
@@ -139,7 +207,8 @@ func TestRunIngestScenarios(t *testing.T) {
 				require.Zero(t, updateCount)
 			},
 		},
-		// Returns early when the caller-provided context is already canceled before any batch starts.
+		// Returns early when the caller-provided context is already canceled
+		// before any batch starts.
 		"context_canceled_before_batch": {
 			fileBatch: 1,
 			strategy:  "onlyingest",
@@ -149,29 +218,55 @@ func TestRunIngestScenarios(t *testing.T) {
 				cancel()
 				return ctx
 			},
-			check: func(t *testing.T, _ RunConfig, _ []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+			check: func(
+				t *testing.T,
+				_ RunConfig,
+				_ []string,
+				err error,
+				runOrder [][]string,
+				coalesceCount int,
+				updateCount int,
+			) {
 				require.ErrorIs(t, err, context.Canceled)
 				require.Empty(t, runOrder)
 				require.Zero(t, coalesceCount)
 				require.Zero(t, updateCount)
 			},
 		},
-		// Runs the default strategy through ingest, coalesce, and SMT update in one pass.
+		// Runs the default strategy through ingest, coalesce,
+		// and SMT update in one pass.
 		"default_strategy_runs_all_phases": {
 			fileBatch: 0,
 			strategy:  "",
-			check: func(t *testing.T, _ RunConfig, _ []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+			check: func(
+				t *testing.T,
+				_ RunConfig,
+				_ []string,
+				err error,
+				runOrder [][]string,
+				coalesceCount int,
+				updateCount int,
+			) {
 				require.NoError(t, err)
 				require.Len(t, runOrder, 1)
 				require.Equal(t, 1, coalesceCount)
 				require.Equal(t, 1, updateCount)
 			},
 		},
-		// Skips file ingestion and runs only coalesce plus SMT update on the carried-forward snapshot.
+		// Skips file ingestion and runs only coalesce plus SMT update
+		// on the carried-forward snapshot.
 		"skipingest_strategy_runs_followup_phases_only": {
 			fileBatch: 0,
 			strategy:  "skipingest",
-			check: func(t *testing.T, _ RunConfig, _ []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+			check: func(
+				t *testing.T,
+				_ RunConfig,
+				_ []string,
+				err error,
+				runOrder [][]string,
+				coalesceCount int,
+				updateCount int,
+			) {
 				require.NoError(t, err)
 				require.Empty(t, runOrder)
 				require.Equal(t, 1, coalesceCount)
@@ -182,7 +277,15 @@ func TestRunIngestScenarios(t *testing.T) {
 		"onlysmtupdate_strategy_runs_smt_only": {
 			fileBatch: 0,
 			strategy:  "onlysmtupdate",
-			check: func(t *testing.T, _ RunConfig, _ []string, err error, runOrder [][]string, coalesceCount int, updateCount int) {
+			check: func(
+				t *testing.T,
+				_ RunConfig,
+				_ []string,
+				err error,
+				runOrder [][]string,
+				coalesceCount int,
+				updateCount int,
+			) {
 				require.NoError(t, err)
 				require.Empty(t, runOrder)
 				require.Zero(t, coalesceCount)
@@ -198,7 +301,12 @@ func TestRunIngestScenarios(t *testing.T) {
 				dir = filepath.Join(t.TempDir(), "does-not-exist")
 			}
 
-			cfg := newTestRunConfig(dir, filepath.Join(t.TempDir(), "journal.json"), tc.fileBatch, tc.strategy)
+			cfg := newTestRunConfig(
+				dir,
+				filepath.Join(t.TempDir(), "journal.json"),
+				tc.fileBatch,
+				tc.strategy,
+			)
 			if tc.prepare != nil {
 				tc.prepare(t, cfg, files)
 			}
@@ -258,7 +366,7 @@ func newTestDeps(
 	t.Helper()
 
 	return RunDependencies{
-		NewJournal: func(cfg RunConfig, jobCfg journal.JobConfiguration) (JournalStore, error) {
+		NewJournal: func(cfg RunConfig, jobCfg journal.JobConfiguration) (*journal.Journal, error) {
 			return journal.NewJournal(cfg.JournalFile, jobCfg, cfg.Directory)
 		},
 		NewStatistics: func() *updater.Stats {
@@ -295,8 +403,8 @@ func loadJournalForTest(t *testing.T, cfg RunConfig) *journal.Journal {
 	return j
 }
 
-func completedIngestTestIntervals(intervals ...journal.Interval) map[string][]journal.Interval {
-	return map[string][]journal.Interval{
+func completedIngestTestIntervals(intervals ...journal.Interval) journal.CompletedIndices {
+	return journal.CompletedIndices{
 		ingestTestBase: intervals,
 	}
 }


### PR DESCRIPTION
- [x] Journal file should contain Jobs, an array of cwd,cmd,jobconfiguration, instead of three separate arrays
- [x] Skip non .gz files unless flag is given
- [x] Make journal keep completed files intervals, instead of single completed files entries
- [x] Use journal to keep track of the last coalesced index, also used in SMT index

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/fpki/92)
<!-- Reviewable:end -->
