### PR TITLE
Force exit on second signal, if not terminated.

### DIFF
--- a/cmd/ingest/diagnostics_test.go
+++ b/cmd/ingest/diagnostics_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -202,4 +204,97 @@ func TestCreateDiagnosticsDirUsesTimestampedNames(t *testing.T) {
 	base := filepath.Base(dir)
 	require.Equal(t, "fpki-diagnostics-20260331-091213.456", base)
 	require.True(t, strings.HasPrefix(base, "fpki-diagnostics-"))
+}
+
+func TestSignalHandlerCancelsOnFirstTerminationSignal(t *testing.T) {
+	signals := make(chan os.Signal, 2)
+	var (
+		interrupted atomic.Bool
+		cancelled   atomic.Int32
+		exits       atomic.Int32
+		profiles    atomic.Int32
+		diagnostics atomic.Int32
+		stderr      bytes.Buffer
+	)
+
+	done := startIngestSignalHandler(signals, RunConfig{}, &stderr, ingestSignalHandlerDeps{
+		stopProfiles: func() error {
+			profiles.Add(1)
+			return nil
+		},
+		createDiagnostics: func(RunConfig, os.Signal, io.Writer) (string, error) {
+			diagnostics.Add(1)
+			return "/tmp/fpki-diagnostics-test", nil
+		},
+		cancel: func() {
+			cancelled.Add(1)
+		},
+		interrupted: &interrupted,
+		exit: func(int) {
+			exits.Add(1)
+		},
+	})
+
+	signals <- syscall.SIGINT
+	close(signals)
+	<-done
+
+	require.True(t, interrupted.Load())
+	require.Equal(t, int32(1), cancelled.Load())
+	require.Equal(t, int32(0), exits.Load())
+	require.Equal(t, int32(1), profiles.Load())
+	require.Equal(t, int32(1), diagnostics.Load())
+	require.Contains(t, stderr.String(), "signal caught: 'interrupt'")
+}
+
+func TestSignalHandlerForcesExitOnSecondTerminationSignal(t *testing.T) {
+	signals := make(chan os.Signal, 2)
+	var (
+		interrupted atomic.Bool
+		cancelled   atomic.Int32
+		exitCode    atomic.Int32
+		stderr      bytes.Buffer
+	)
+
+	done := startIngestSignalHandler(signals, RunConfig{}, &stderr, ingestSignalHandlerDeps{
+		stopProfiles: func() error { return nil },
+		createDiagnostics: func(RunConfig, os.Signal, io.Writer) (string, error) {
+			return "", nil
+		},
+		cancel: func() {
+			cancelled.Add(1)
+		},
+		interrupted: &interrupted,
+		exit: func(code int) {
+			exitCode.Store(int32(code))
+		},
+	})
+
+	signals <- syscall.SIGINT
+	signals <- syscall.SIGINT
+	<-done
+
+	require.True(t, interrupted.Load())
+	require.Equal(t, int32(1), cancelled.Load())
+	require.Equal(t, int32(128+int32(syscall.SIGINT)), exitCode.Load())
+	require.Contains(t, stderr.String(), "forcing immediate exit on second signal")
+}
+
+func TestSignalHandlerPanicsWhenRequiredDepsAreMissing(t *testing.T) {
+	signals := make(chan os.Signal, 1)
+	var stderr bytes.Buffer
+
+	require.PanicsWithValue(t,
+		"startIngestSignalHandler: interrupted is nil",
+		func() {
+			startIngestSignalHandler(signals, RunConfig{}, &stderr, ingestSignalHandlerDeps{
+				stopProfiles: func() error { return nil },
+				createDiagnostics: func(RunConfig, os.Signal, io.Writer) (string, error) {
+					return "", nil
+				},
+				cancel: func() {},
+				exit:   func(int) {},
+			})
+		},
+	)
 }

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -140,28 +140,13 @@ func mainFunction() error {
 	defer signal.Stop(signals)
 
 	var interrupted atomic.Bool
-	go func() {
-		for sg := range signals {
-			fmt.Fprintf(os.Stderr, "\n%s: signal caught: '%s'\n", time.Now().String(), sg.String())
-			if sg == syscall.SIGINT || sg == syscall.SIGTERM {
-				if err := stopProfiles(); err != nil {
-					fmt.Fprintf(os.Stderr, "%s\n", err)
-				}
-			}
-			dir, err := createDiagnosticsBundle(cfg, sg, os.Stderr)
-			if dir != "" {
-				fmt.Fprintf(os.Stderr, "\nDiagnostics dumped to %s\n", dir)
-			}
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "%s\n", err)
-			}
-			if sg == syscall.SIGINT || sg == syscall.SIGTERM {
-				interrupted.Store(true)
-				cancel()
-				return
-			}
-		}
-	}()
+	startIngestSignalHandler(signals, cfg, os.Stderr, ingestSignalHandlerDeps{
+		stopProfiles:      stopProfiles,
+		createDiagnostics: createDiagnosticsBundle,
+		cancel:            cancel,
+		interrupted:       &interrupted,
+		exit:              util.Exit,
+	})
 
 	err = runIngestContext(ctx, cfg, RunDependencies{
 		NewJournal: func(cfg RunConfig, jobCfg journal.JobConfiguration) (JournalStore, error) {
@@ -277,6 +262,85 @@ func configFromFlags() RunConfig {
 		CpuProfile:       *args.CpuProfile,
 		MemProfile:       *args.MemProfile,
 	}
+}
+
+type ingestSignalHandlerDeps struct {
+	stopProfiles      func() error
+	createDiagnostics func(RunConfig, os.Signal, io.Writer) (string, error)
+	cancel            context.CancelFunc
+	interrupted       *atomic.Bool
+	exit              func(int)
+}
+
+func startIngestSignalHandler(
+	signals <-chan os.Signal,
+	cfg RunConfig,
+	stderr io.Writer,
+	deps ingestSignalHandlerDeps,
+) <-chan struct{} {
+	if stderr == nil {
+		panic("startIngestSignalHandler: stderr is nil")
+	}
+	if deps.stopProfiles == nil {
+		panic("startIngestSignalHandler: stopProfiles is nil")
+	}
+	if deps.createDiagnostics == nil {
+		panic("startIngestSignalHandler: createDiagnostics is nil")
+	}
+	if deps.cancel == nil {
+		panic("startIngestSignalHandler: cancel is nil")
+	}
+	if deps.interrupted == nil {
+		panic("startIngestSignalHandler: interrupted is nil")
+	}
+	if deps.exit == nil {
+		panic("startIngestSignalHandler: exit is nil")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		terminationRequested := false
+		for sg := range signals {
+			fmt.Fprintf(stderr, "\n%s: signal caught: '%s'\n", time.Now().String(), sg.String())
+
+			isTermination := sg == syscall.SIGINT || sg == syscall.SIGTERM
+			if isTermination && terminationRequested {
+				fmt.Fprintf(stderr, "forcing immediate exit on second signal: '%s'\n", sg.String())
+				deps.exit(signalExitCode(sg))
+				return
+			}
+
+			if isTermination {
+				terminationRequested = true
+				if err := deps.stopProfiles(); err != nil {
+					fmt.Fprintf(stderr, "%s\n", err)
+				}
+			}
+
+			dir, err := deps.createDiagnostics(cfg, sg, stderr)
+			if dir != "" {
+				fmt.Fprintf(stderr, "\nDiagnostics dumped to %s\n", dir)
+			}
+			if err != nil {
+				fmt.Fprintf(stderr, "%s\n", err)
+			}
+
+			if isTermination {
+				deps.interrupted.Store(true)
+				deps.cancel()
+			}
+		}
+	}()
+	return done
+}
+
+func signalExitCode(sg os.Signal) int {
+	if sg == syscall.SIGTERM {
+		return 128 + int(syscall.SIGTERM)
+	}
+	return 128 + int(syscall.SIGINT)
 }
 
 var diagnosticsRootDir = os.TempDir()


### PR DESCRIPTION
If the pipeline is blocked on one of the workers' `Wait`, the signal handler needs to terminate the process.
This is necessary for the journal to be written, and for the process to finally quit.

Make the signal handler quit the process on the second time it's handling a termination signal.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/fpki/93)
<!-- Reviewable:end -->
