### PR TITLE
SMT update performance and less RAM

### DIFF
--- a/pkg/common/ids.go
+++ b/pkg/common/ids.go
@@ -38,3 +38,16 @@ func SortIDsAndGlue(IDs []SHA256Output) []byte {
 	})
 	return IDsToBytes(ids)
 }
+
+// SortIDsAndHash sorts the IDs alphabetically and returns the SHA256 of the glued bytes.
+func SortIDsAndHash(IDs []SHA256Output) []byte {
+	if len(IDs) == 0 {
+		return nil
+	}
+
+	ids := append(IDs[:0:0], IDs...)
+	sort.Slice(ids, func(i, j int) bool {
+		return bytes.Compare(ids[i][:], ids[j][:]) == -1
+	})
+	return SHA256Hash(IDsToBytes(ids))
+}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -14,6 +14,14 @@ type KeyValuePair struct {
 	Value []byte
 }
 
+// DirtyDomainEntriesCursor tracks per-partition progress while retrieving dirty-domain
+// entries in bounded bundles.
+type DirtyDomainEntriesCursor struct {
+	PartitionOffsets   []uint64
+	PartitionExhausted []bool
+	NextPartition      int
+}
+
 type smt interface {
 	LoadRoot(ctx context.Context) (*common.SHA256Output, error)
 	SaveRoot(ctx context.Context, root *common.SHA256Output) error
@@ -162,4 +170,13 @@ type Conn interface {
 	// RetrieveDomainEntriesDirtyOnes returns a list of key-values whose domain IDs are specified
 	// by the dirty table entries starting from `start` and not including `end`.
 	RetrieveDomainEntriesDirtyOnes(ctx context.Context, start, end uint64) ([]KeyValuePair, error)
+
+	// RetrieveDomainEntriesDirtyBundle retrieves up to maxBundleSize dirty-domain entries using
+	// partition-local progress tracked in cursor. The returned cursor must be passed to the next
+	// call. done reports whether all partitions have been fully consumed.
+	RetrieveDomainEntriesDirtyBundle(
+		ctx context.Context,
+		cursor *DirtyDomainEntriesCursor,
+		maxBundleSize uint64,
+	) ([]KeyValuePair, *DirtyDomainEntriesCursor, bool, error)
 }

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -8,10 +8,19 @@ import (
 	"github.com/netsec-ethz/fpki/pkg/common"
 )
 
-// KeyValuePair: key-value pair
-type KeyValuePair struct {
+// TreeNodeRecord stores one serialized SMT node as persisted in the tree table.
+// Key is the hash of the SMT node; Value is the serialized trie batch.
+type TreeNodeRecord struct {
 	Key   common.SHA256Output
 	Value []byte
+}
+
+// DomainEntryRecord stores one domain entry as consumed by the SMT updater.
+// DomainID is SHA256(domain name); Payload is the byte representation from
+// which the SMT leaf value is derived.
+type DomainEntryRecord struct {
+	DomainID common.SHA256Output
+	Payload  []byte
 }
 
 // DirtyDomainEntriesCursor tracks per-partition progress while retrieving dirty-domain
@@ -26,11 +35,11 @@ type smt interface {
 	LoadRoot(ctx context.Context) (*common.SHA256Output, error)
 	SaveRoot(ctx context.Context, root *common.SHA256Output) error
 
-	// RetrieveTreeNode: Retrieve one key-value pair from Tree table.
+	// RetrieveTreeNode retrieves one serialized SMT node from the tree table.
 	RetrieveTreeNode(ctx context.Context, id common.SHA256Output) ([]byte, error)
-	// UpdateTreeNodes: Update a list of key-value pairs in Tree table
-	UpdateTreeNodes(ctx context.Context, keyValuePairs []*KeyValuePair) (int, error)
-	// DeleteTreeNodes: Delete a list of key-value pairs in Tree table
+	// UpdateTreeNodes updates a list of SMT node records in the tree table.
+	UpdateTreeNodes(ctx context.Context, keyValuePairs []*TreeNodeRecord) (int, error)
+	// DeleteTreeNodes deletes a list of SMT node rows from the tree table.
 	DeleteTreeNodes(ctx context.Context, keys []common.SHA256Output) (int, error)
 }
 
@@ -161,15 +170,15 @@ type Conn interface {
 		domainNames []string,
 	) error
 
-	// RetrieveDomainEntries: Retrieve a list of domain entries table
+	// RetrieveDomainEntries retrieves domain-entry payloads for the specified domain IDs.
 	RetrieveDomainEntries(
 		ctx context.Context,
 		ids []common.SHA256Output,
-	) ([]KeyValuePair, error)
+	) ([]DomainEntryRecord, error)
 
 	// RetrieveDomainEntriesDirtyOnes returns a list of key-values whose domain IDs are specified
 	// by the dirty table entries starting from `start` and not including `end`.
-	RetrieveDomainEntriesDirtyOnes(ctx context.Context, start, end uint64) ([]KeyValuePair, error)
+	RetrieveDomainEntriesDirtyOnes(ctx context.Context, start, end uint64) ([]DomainEntryRecord, error)
 
 	// RetrieveDomainEntriesDirtyBundle retrieves up to maxBundleSize dirty-domain entries using
 	// partition-local progress tracked in cursor. The returned cursor must be passed to the next
@@ -178,5 +187,5 @@ type Conn interface {
 		ctx context.Context,
 		cursor *DirtyDomainEntriesCursor,
 		maxBundleSize uint64,
-	) ([]KeyValuePair, *DirtyDomainEntriesCursor, bool, error)
+	) ([]DomainEntryRecord, *DirtyDomainEntriesCursor, bool, error)
 }

--- a/pkg/db/mock_db/conn.go
+++ b/pkg/db/mock_db/conn.go
@@ -280,10 +280,10 @@ func (mr *MockConnMockRecorder) RetrieveDomainCertificatesIDs(arg0, arg1 any) *g
 }
 
 // RetrieveDomainEntries mocks base method.
-func (m *MockConn) RetrieveDomainEntries(arg0 context.Context, arg1 []common.SHA256Output) ([]db.KeyValuePair, error) {
+func (m *MockConn) RetrieveDomainEntries(arg0 context.Context, arg1 []common.SHA256Output) ([]db.DomainEntryRecord, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RetrieveDomainEntries", arg0, arg1)
-	ret0, _ := ret[0].([]db.KeyValuePair)
+	ret0, _ := ret[0].([]db.DomainEntryRecord)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -295,10 +295,10 @@ func (mr *MockConnMockRecorder) RetrieveDomainEntries(arg0, arg1 any) *gomock.Ca
 }
 
 // RetrieveDomainEntriesDirtyOnes mocks base method.
-func (m *MockConn) RetrieveDomainEntriesDirtyOnes(arg0 context.Context, arg1, arg2 uint64) ([]db.KeyValuePair, error) {
+func (m *MockConn) RetrieveDomainEntriesDirtyOnes(arg0 context.Context, arg1, arg2 uint64) ([]db.DomainEntryRecord, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RetrieveDomainEntriesDirtyOnes", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]db.KeyValuePair)
+	ret0, _ := ret[0].([]db.DomainEntryRecord)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -310,10 +310,10 @@ func (mr *MockConnMockRecorder) RetrieveDomainEntriesDirtyOnes(arg0, arg1, arg2 
 }
 
 // RetrieveDomainEntriesDirtyBundle mocks base method.
-func (m *MockConn) RetrieveDomainEntriesDirtyBundle(arg0 context.Context, arg1 *db.DirtyDomainEntriesCursor, arg2 uint64) ([]db.KeyValuePair, *db.DirtyDomainEntriesCursor, bool, error) {
+func (m *MockConn) RetrieveDomainEntriesDirtyBundle(arg0 context.Context, arg1 *db.DirtyDomainEntriesCursor, arg2 uint64) ([]db.DomainEntryRecord, *db.DirtyDomainEntriesCursor, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RetrieveDomainEntriesDirtyBundle", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]db.KeyValuePair)
+	ret0, _ := ret[0].([]db.DomainEntryRecord)
 	ret1, _ := ret[1].(*db.DirtyDomainEntriesCursor)
 	ret2, _ := ret[2].(bool)
 	ret3, _ := ret[3].(error)
@@ -485,7 +485,7 @@ func (mr *MockConnMockRecorder) UpdatePolicies(arg0, arg1, arg2, arg3, arg4 any)
 }
 
 // UpdateTreeNodes mocks base method.
-func (m *MockConn) UpdateTreeNodes(arg0 context.Context, arg1 []*db.KeyValuePair) (int, error) {
+func (m *MockConn) UpdateTreeNodes(arg0 context.Context, arg1 []*db.TreeNodeRecord) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateTreeNodes", arg0, arg1)
 	ret0, _ := ret[0].(int)

--- a/pkg/db/mock_db/conn.go
+++ b/pkg/db/mock_db/conn.go
@@ -309,6 +309,23 @@ func (mr *MockConnMockRecorder) RetrieveDomainEntriesDirtyOnes(arg0, arg1, arg2 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveDomainEntriesDirtyOnes", reflect.TypeOf((*MockConn)(nil).RetrieveDomainEntriesDirtyOnes), arg0, arg1, arg2)
 }
 
+// RetrieveDomainEntriesDirtyBundle mocks base method.
+func (m *MockConn) RetrieveDomainEntriesDirtyBundle(arg0 context.Context, arg1 *db.DirtyDomainEntriesCursor, arg2 uint64) ([]db.KeyValuePair, *db.DirtyDomainEntriesCursor, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RetrieveDomainEntriesDirtyBundle", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]db.KeyValuePair)
+	ret1, _ := ret[1].(*db.DirtyDomainEntriesCursor)
+	ret2, _ := ret[2].(bool)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
+}
+
+// RetrieveDomainEntriesDirtyBundle indicates an expected call of RetrieveDomainEntriesDirtyBundle.
+func (mr *MockConnMockRecorder) RetrieveDomainEntriesDirtyBundle(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveDomainEntriesDirtyBundle", reflect.TypeOf((*MockConn)(nil).RetrieveDomainEntriesDirtyBundle), arg0, arg1, arg2)
+}
+
 // RetrieveDomainPoliciesIDs mocks base method.
 func (m *MockConn) RetrieveDomainPoliciesIDs(arg0 context.Context, arg1 common.SHA256Output) (common.SHA256Output, []byte, error) {
 	m.ctrl.T.Helper()

--- a/pkg/db/mysql/export_test.go
+++ b/pkg/db/mysql/export_test.go
@@ -24,14 +24,6 @@ func (c *MysqlDBForTests) DebugCheckCertsExist(ctx context.Context, ids []common
 	return c.checkCertsExist(ctx, ids, present)
 }
 
-func (c *MysqlDBForTests) RetrieveDirtyDomainEntriesInDBJoin(
-	ctx context.Context,
-	start, end uint64,
-) ([]db.KeyValuePair, error) {
-
-	return c.retrieveDirtyDomainEntriesInDBJoin(ctx, start, end)
-}
-
 func (c *MysqlDBForTests) RetrieveDirtyDomainEntriesParallel(
 	ctx context.Context,
 	domainIDs []common.SHA256Output,

--- a/pkg/db/mysql/export_test.go
+++ b/pkg/db/mysql/export_test.go
@@ -12,6 +12,7 @@ type MysqlDBForTests struct {
 	*mysqlDB
 }
 
+// NewMysqlDBForTests exposes mysqlDB internals to package tests.
 func NewMysqlDBForTests(db db.Conn) *MysqlDBForTests {
 	return &MysqlDBForTests{
 		mysqlDB: db.(*mysqlDB),
@@ -27,7 +28,7 @@ func (c *MysqlDBForTests) DebugCheckCertsExist(ctx context.Context, ids []common
 func (c *MysqlDBForTests) RetrieveDirtyDomainEntriesParallel(
 	ctx context.Context,
 	domainIDs []common.SHA256Output,
-) ([]db.KeyValuePair, error) {
+) ([]db.DomainEntryRecord, error) {
 
 	return c.retrieveDirtyDomainEntriesParallel(ctx, domainIDs)
 }
@@ -35,7 +36,7 @@ func (c *MysqlDBForTests) RetrieveDirtyDomainEntriesParallel(
 func (c *MysqlDBForTests) RetrieveDirtyDomainEntriesSequential(
 	ctx context.Context,
 	domainIDs []common.SHA256Output,
-) ([]db.KeyValuePair, error) {
+) ([]db.DomainEntryRecord, error) {
 
 	return c.retrieveDirtyDomainEntriesSequential(ctx, domainIDs)
 }

--- a/pkg/db/mysql/mysql.go
+++ b/pkg/db/mysql/mysql.go
@@ -215,6 +215,92 @@ func (c *mysqlDB) RetrieveDomainEntriesDirtyOnes(
 	return extractDomainEntries(rows)
 }
 
+func (c *mysqlDB) RetrieveDomainEntriesDirtyBundle(
+	ctx context.Context,
+	cursor *db.DirtyDomainEntriesCursor,
+	maxBundleSize uint64,
+) ([]db.KeyValuePair, *db.DirtyDomainEntriesCursor, bool, error) {
+	if maxBundleSize == 0 {
+		return nil, cursor, true, fmt.Errorf("max bundle size must be > 0")
+	}
+
+	state := normalizeDirtyDomainEntriesCursor(cursor)
+	bundle := make([]db.KeyValuePair, 0, maxBundleSize)
+
+	for uint64(len(bundle)) < maxBundleSize {
+		activePartitions := activeDirtyPartitions(state)
+		if len(activePartitions) == 0 {
+			return bundle, state, true, nil
+		}
+
+		requests := distributeDirtyBundleRequests(activePartitions, maxBundleSize-uint64(len(bundle)))
+		partitionEntries := make([][]db.KeyValuePair, NumPartitions)
+		fetchedCounts := make([]uint64, NumPartitions)
+		errs := make([]error, NumPartitions)
+
+		var wg sync.WaitGroup
+		for _, partition := range activePartitions {
+			limit := requests[partition]
+			if limit == 0 {
+				continue
+			}
+
+			wg.Add(1)
+			go func(partition int, limit uint64) {
+				defer wg.Done()
+
+				ids, err := c.retrieveDirtyDomainIDsForPartition(
+					ctx,
+					partition,
+					state.PartitionOffsets[partition],
+					limit,
+				)
+				if err != nil {
+					errs[partition] = err
+					return
+				}
+
+				fetchedCounts[partition] = uint64(len(ids))
+				if len(ids) == 0 {
+					return
+				}
+
+				partitionEntries[partition], err = c.retrieveDirtyDomainEntriesPreserveMissing(ctx, ids)
+				if err != nil {
+					errs[partition] = err
+				}
+			}(partition, limit)
+		}
+		wg.Wait()
+
+		if err := util.ErrorsCoalesce(errs...); err != nil {
+			return nil, state, false, err
+		}
+
+		progressMade := false
+		for _, partition := range activePartitions {
+			fetched := fetchedCounts[partition]
+			if fetched > 0 {
+				progressMade = true
+				state.PartitionOffsets[partition] += fetched
+				bundle = append(bundle, partitionEntries[partition]...)
+			}
+			if fetched < requests[partition] {
+				state.PartitionExhausted[partition] = true
+			}
+		}
+		if len(activePartitions) > 0 {
+			state.NextPartition = (activePartitions[0] + 1) % NumPartitions
+		}
+
+		if !progressMade {
+			continue
+		}
+	}
+
+	return bundle, state, len(activeDirtyPartitions(state)) == 0, nil
+}
+
 // retrieveDirtyDomainEntriesParallel uses retrieveDomainEntriesSequential NumDBWorkers times to
 // query the (huge) table domain_payloads values that match the passed argument.
 //
@@ -300,7 +386,123 @@ func (c *mysqlDB) retrieveDirtyDomainEntriesSequential(
 	return extractDomainEntries(rows)
 }
 
+func (c *mysqlDB) retrieveDirtyDomainEntriesPreserveMissing(
+	ctx context.Context,
+	domainIDs []common.SHA256Output,
+) ([]db.KeyValuePair, error) {
+	if len(domainIDs) == 0 {
+		return nil, nil
+	}
+
+	pairs, err := c.retrieveDirtyDomainEntriesSequential(ctx, domainIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	valuesByKey := make(map[common.SHA256Output][]byte, len(pairs))
+	for _, pair := range pairs {
+		valuesByKey[pair.Key] = pair.Value
+	}
+
+	result := make([]db.KeyValuePair, 0, len(domainIDs))
+	for _, id := range domainIDs {
+		result = append(result, db.KeyValuePair{
+			Key:   id,
+			Value: valuesByKey[id],
+		})
+	}
+	return result, nil
+}
+
+func (c *mysqlDB) retrieveDirtyDomainIDsForPartition(
+	ctx context.Context,
+	partition int,
+	offset uint64,
+	limit uint64,
+) ([]common.SHA256Output, error) {
+	if limit == 0 {
+		return nil, nil
+	}
+
+	str := fmt.Sprintf(
+		"SELECT domain_id FROM dirty PARTITION(p%d) ORDER BY domain_id LIMIT ?,?",
+		partition,
+	)
+	rows, err := c.db.QueryContext(ctx, str, offset, limit)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving dirty domain IDs from partition %d offset %d limit %d: %w",
+			partition, offset, limit, err)
+	}
+	defer rows.Close()
+
+	ids := make([]common.SHA256Output, 0, limit)
+	for rows.Next() {
+		var domainID []byte
+		if err := rows.Scan(&domainID); err != nil {
+			return nil, fmt.Errorf("scanning dirty domain ID from partition %d: %w", partition, err)
+		}
+		ids = append(ids, common.SHA256Output(domainID))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating dirty domain IDs from partition %d: %w", partition, err)
+	}
+	return ids, nil
+}
+
+func normalizeDirtyDomainEntriesCursor(
+	cursor *db.DirtyDomainEntriesCursor,
+) *db.DirtyDomainEntriesCursor {
+	if cursor == nil {
+		return &db.DirtyDomainEntriesCursor{
+			PartitionOffsets:   make([]uint64, NumPartitions),
+			PartitionExhausted: make([]bool, NumPartitions),
+		}
+	}
+
+	state := &db.DirtyDomainEntriesCursor{
+		PartitionOffsets:   make([]uint64, NumPartitions),
+		PartitionExhausted: make([]bool, NumPartitions),
+	}
+	copy(state.PartitionOffsets, cursor.PartitionOffsets)
+	copy(state.PartitionExhausted, cursor.PartitionExhausted)
+	if NumPartitions > 0 {
+		state.NextPartition = cursor.NextPartition % NumPartitions
+	}
+	return state
+}
+
+func activeDirtyPartitions(cursor *db.DirtyDomainEntriesCursor) []int {
+	partitions := make([]int, 0, NumPartitions)
+	for i := 0; i < NumPartitions; i++ {
+		partition := (cursor.NextPartition + i) % NumPartitions
+		if cursor.PartitionExhausted[partition] {
+			continue
+		}
+		partitions = append(partitions, partition)
+	}
+	return partitions
+}
+
+func distributeDirtyBundleRequests(activePartitions []int, remaining uint64) []uint64 {
+	requests := make([]uint64, NumPartitions)
+	if remaining == 0 || len(activePartitions) == 0 {
+		return requests
+	}
+
+	base := remaining / uint64(len(activePartitions))
+	extra := remaining % uint64(len(activePartitions))
+	for i, partition := range activePartitions {
+		requests[partition] = base
+		if uint64(i) < extra {
+			requests[partition]++
+		}
+	}
+	return requests
+}
+
 func extractDomainEntries(rows *sql.Rows) ([]db.KeyValuePair, error) {
+	defer rows.Close()
+
 	pairs := make([]db.KeyValuePair, 0)
 	for rows.Next() {
 		var id, certIDs, policyIDs []byte
@@ -314,6 +516,9 @@ func extractDomainEntries(rows *sql.Rows) ([]db.KeyValuePair, error) {
 			Key:   *(*common.SHA256Output)(id),
 			Value: common.SortIDsAndGlue(allIDs),
 		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating domain entries: %w", err)
 	}
 	return pairs, nil
 }

--- a/pkg/db/mysql/mysql.go
+++ b/pkg/db/mysql/mysql.go
@@ -194,23 +194,19 @@ func (c *mysqlDB) RetrieveDomainEntries(ctx context.Context, domainIDs []common.
 	return c.retrieveDirtyDomainEntriesSequential(ctx, domainIDs)
 }
 
-func (c *mysqlDB) RetrieveDomainEntriesDirtyOnes(ctx context.Context, start, end uint64,
-) ([]db.KeyValuePair, error) {
-	return c.retrieveDirtyDomainEntriesInDBJoin(ctx, start, end)
-}
-
-func (c *mysqlDB) retrieveDirtyDomainEntriesInDBJoin(
+func (c *mysqlDB) RetrieveDomainEntriesDirtyOnes(
 	ctx context.Context,
-	start, end uint64,
+	start uint64,
+	end uint64,
 ) ([]db.KeyValuePair, error) {
 
-	str := `SELECT d.domain_id,p.cert_ids,p.policy_ids
+	str := `SELECT d.domain_id,dp.cert_ids,dp.policy_ids
 		FROM
 		(SELECT domain_id FROM dirty ORDER BY domain_id LIMIT ?,? )
 		AS d
 		LEFT JOIN
-		domain_payloads AS p
-		ON d.domain_id=p.domain_id;`
+		domain_payloads AS dp
+		ON d.domain_id=dp.domain_id;`
 	rows, err := c.db.QueryContext(ctx, str, start, end-start)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving domain payloads from dirty[%d,%d): %w",

--- a/pkg/db/mysql/mysql.go
+++ b/pkg/db/mysql/mysql.go
@@ -510,11 +510,11 @@ func extractDomainEntries(rows *sql.Rows) ([]db.KeyValuePair, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error scanning domain ID and its certs/policies")
 		}
-		// Unfold the byte streams into IDs, sort them, and fold again.
+		// The SMT only needs the final leaf hash, not the full glued payload bytes.
 		allIDs := append(common.BytesToIDs(certIDs), common.BytesToIDs(policyIDs)...)
 		pairs = append(pairs, db.KeyValuePair{
 			Key:   *(*common.SHA256Output)(id),
-			Value: common.SortIDsAndGlue(allIDs),
+			Value: common.SortIDsAndHash(allIDs),
 		})
 	}
 	if err := rows.Err(); err != nil {

--- a/pkg/db/mysql/mysql.go
+++ b/pkg/db/mysql/mysql.go
@@ -181,10 +181,10 @@ func (c *mysqlDB) updateDomainsMemory(
 	return nil
 }
 
-// RetrieveDomainEntries: Retrieve a list of key-value pairs from domain entries table
-// No sql.ErrNoRows will be thrown, if some records does not exist. Check the length of result
+// RetrieveDomainEntries retrieves domain-entry payloads for the specified domain IDs.
+// Missing payload rows are omitted from the result; callers should check the result length.
 func (c *mysqlDB) RetrieveDomainEntries(ctx context.Context, domainIDs []common.SHA256Output,
-) ([]db.KeyValuePair, error) {
+) ([]db.DomainEntryRecord, error) {
 
 	if len(domainIDs) == 0 {
 		return nil, nil
@@ -198,7 +198,7 @@ func (c *mysqlDB) RetrieveDomainEntriesDirtyOnes(
 	ctx context.Context,
 	start uint64,
 	end uint64,
-) ([]db.KeyValuePair, error) {
+) ([]db.DomainEntryRecord, error) {
 
 	str := `SELECT d.domain_id,dp.cert_ids,dp.policy_ids
 		FROM
@@ -219,13 +219,13 @@ func (c *mysqlDB) RetrieveDomainEntriesDirtyBundle(
 	ctx context.Context,
 	cursor *db.DirtyDomainEntriesCursor,
 	maxBundleSize uint64,
-) ([]db.KeyValuePair, *db.DirtyDomainEntriesCursor, bool, error) {
+) ([]db.DomainEntryRecord, *db.DirtyDomainEntriesCursor, bool, error) {
 	if maxBundleSize == 0 {
 		return nil, cursor, true, fmt.Errorf("max bundle size must be > 0")
 	}
 
 	state := normalizeDirtyDomainEntriesCursor(cursor)
-	bundle := make([]db.KeyValuePair, 0, maxBundleSize)
+	bundle := make([]db.DomainEntryRecord, 0, maxBundleSize)
 
 	for uint64(len(bundle)) < maxBundleSize {
 		activePartitions := activeDirtyPartitions(state)
@@ -234,7 +234,7 @@ func (c *mysqlDB) RetrieveDomainEntriesDirtyBundle(
 		}
 
 		requests := distributeDirtyBundleRequests(activePartitions, maxBundleSize-uint64(len(bundle)))
-		partitionEntries := make([][]db.KeyValuePair, NumPartitions)
+		partitionEntries := make([][]db.DomainEntryRecord, NumPartitions)
 		fetchedCounts := make([]uint64, NumPartitions)
 		errs := make([]error, NumPartitions)
 
@@ -309,10 +309,10 @@ func (c *mysqlDB) RetrieveDomainEntriesDirtyBundle(
 func (c *mysqlDB) retrieveDirtyDomainEntriesParallel(
 	ctx context.Context,
 	domainIDs []common.SHA256Output,
-) ([]db.KeyValuePair, error) {
+) ([]db.DomainEntryRecord, error) {
 
 	// Function closure that concurrently asks to retrieve the domainsPerWorker given the IDs.
-	domainsPerWorker := make([][]db.KeyValuePair, NumDBWorkers)
+	domainsPerWorker := make([][]db.DomainEntryRecord, NumDBWorkers)
 	errs := make([]error, NumDBWorkers)
 	wg := sync.WaitGroup{}
 	bundler := func(offset, fromWorker, toWorker, blockSize int) {
@@ -356,7 +356,7 @@ func (c *mysqlDB) retrieveDirtyDomainEntriesParallel(
 	}
 
 	// Place each bundle in its place.
-	allDomains := make([]db.KeyValuePair, 0, len(domainIDs))
+	allDomains := make([]db.DomainEntryRecord, 0, len(domainIDs))
 	for _, ids := range domainsPerWorker {
 		allDomains = append(allDomains, ids...)
 	}
@@ -368,7 +368,7 @@ func (c *mysqlDB) retrieveDirtyDomainEntriesParallel(
 func (c *mysqlDB) retrieveDirtyDomainEntriesSequential(
 	ctx context.Context,
 	domainIDs []common.SHA256Output,
-) ([]db.KeyValuePair, error) {
+) ([]db.DomainEntryRecord, error) {
 
 	// Retrieve the certificate and policy IDs for each domain ID.
 	str := "SELECT domain_id,cert_ids,policy_ids FROM domain_payloads WHERE domain_id IN " +
@@ -389,7 +389,7 @@ func (c *mysqlDB) retrieveDirtyDomainEntriesSequential(
 func (c *mysqlDB) retrieveDirtyDomainEntriesPreserveMissing(
 	ctx context.Context,
 	domainIDs []common.SHA256Output,
-) ([]db.KeyValuePair, error) {
+) ([]db.DomainEntryRecord, error) {
 	if len(domainIDs) == 0 {
 		return nil, nil
 	}
@@ -401,14 +401,14 @@ func (c *mysqlDB) retrieveDirtyDomainEntriesPreserveMissing(
 
 	valuesByKey := make(map[common.SHA256Output][]byte, len(pairs))
 	for _, pair := range pairs {
-		valuesByKey[pair.Key] = pair.Value
+		valuesByKey[pair.DomainID] = pair.Payload
 	}
 
-	result := make([]db.KeyValuePair, 0, len(domainIDs))
+	result := make([]db.DomainEntryRecord, 0, len(domainIDs))
 	for _, id := range domainIDs {
-		result = append(result, db.KeyValuePair{
-			Key:   id,
-			Value: valuesByKey[id],
+		result = append(result, db.DomainEntryRecord{
+			DomainID: id,
+			Payload:  valuesByKey[id],
 		})
 	}
 	return result, nil
@@ -500,27 +500,39 @@ func distributeDirtyBundleRequests(activePartitions []int, remaining uint64) []u
 	return requests
 }
 
-func extractDomainEntries(rows *sql.Rows) ([]db.KeyValuePair, error) {
+// collectRows scans all rows with the provided row-mapper and closes the input rows.
+func collectRows[T any](rows *sql.Rows, scan func(*sql.Rows) (T, error)) ([]T, error) {
 	defer rows.Close()
 
-	pairs := make([]db.KeyValuePair, 0)
+	items := make([]T, 0)
 	for rows.Next() {
+		item, err := scan(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+// extractDomainEntries scans domain-entry payload rows while preserving the
+// original payload semantics expected by the SMT updater and DB tests.
+func extractDomainEntries(rows *sql.Rows) ([]db.DomainEntryRecord, error) {
+	return collectRows(rows, func(rows *sql.Rows) (db.DomainEntryRecord, error) {
 		var id, certIDs, policyIDs []byte
 		err := rows.Scan(&id, &certIDs, &policyIDs)
 		if err != nil {
-			return nil, fmt.Errorf("error scanning domain ID and its certs/policies")
+			return db.DomainEntryRecord{}, fmt.Errorf("error scanning domain ID and its certs/policies")
 		}
-		// The SMT only needs the final leaf hash, not the full glued payload bytes.
 		allIDs := append(common.BytesToIDs(certIDs), common.BytesToIDs(policyIDs)...)
-		pairs = append(pairs, db.KeyValuePair{
-			Key:   *(*common.SHA256Output)(id),
-			Value: common.SortIDsAndHash(allIDs),
-		})
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterating domain entries: %w", err)
-	}
-	return pairs, nil
+		return db.DomainEntryRecord{
+			DomainID: *(*common.SHA256Output)(id),
+			Payload:  common.SortIDsAndGlue(allIDs),
+		}, nil
+	})
 }
 
 func loadDomainsTableWithCSV(

--- a/pkg/db/mysql/mysql.go
+++ b/pkg/db/mysql/mysql.go
@@ -208,7 +208,7 @@ func (c *mysqlDB) retrieveDirtyDomainEntriesInDBJoin(
 		FROM
 		(SELECT domain_id FROM dirty ORDER BY domain_id LIMIT ?,? )
 		AS d
-		JOIN
+		LEFT JOIN
 		domain_payloads AS p
 		ON d.domain_id=p.domain_id;`
 	rows, err := c.db.QueryContext(ctx, str, start, end-start)

--- a/pkg/db/mysql/mysql_test.go
+++ b/pkg/db/mysql/mysql_test.go
@@ -741,7 +741,7 @@ func TestRetrieveDomainEntries(t *testing.T) {
 	require.NoError(t, err)
 	t.Logf("Got data from parallel retrieve at %s", time.Now().Format(time.StampMilli))
 
-	joined, err := c.RetrieveDirtyDomainEntriesInDBJoin(ctx, 0, uint64(len(domainIDs)))
+	joined, err := c.RetrieveDomainEntriesDirtyOnes(ctx, 0, uint64(len(domainIDs)))
 	require.NoError(t, err)
 	t.Logf("Got data from db join retrieve at %s", time.Now().Format(time.StampMilli))
 
@@ -908,7 +908,7 @@ func BenchmarkRetrieveDomainEntries(b *testing.B) {
 
 		b.Run(str+"dirty-join", func(b *testing.B) {
 			bdr.run(func(ctx context.Context) ([]db.KeyValuePair, error) {
-				return c.RetrieveDirtyDomainEntriesInDBJoin(ctx, 0, uint64(i))
+				return c.RetrieveDomainEntriesDirtyOnes(ctx, 0, uint64(i))
 			})
 		})
 		require.Greater(b, bdr.count, 0)

--- a/pkg/db/mysql/mysql_test.go
+++ b/pkg/db/mysql/mysql_test.go
@@ -714,7 +714,7 @@ func TestPruneCerts(t *testing.T) {
 }
 
 func TestRetrieveDomainEntries(t *testing.T) {
-	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancelF := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancelF()
 
 	// Configure a test DB.

--- a/pkg/db/mysql/mysql_test.go
+++ b/pkg/db/mysql/mysql_test.go
@@ -758,6 +758,114 @@ func TestRetrieveDomainEntries(t *testing.T) {
 	require.NotSame(t, expected, joined)
 }
 
+func TestRetrieveDomainEntriesDirtyBundle(t *testing.T) {
+	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelF()
+
+	config, removeF := testdb.ConfigureTestDB(t)
+	defer removeF()
+
+	conn := testdb.Connect(t, config)
+	defer conn.Close()
+
+	c := mysql.NewMysqlDBForTests(conn)
+
+	domainIDs := []common.SHA256Output{
+		dirtyDomainIDForPartition(0, 1),
+		dirtyDomainIDForPartition(0, 2),
+		dirtyDomainIDForPartition(0, 3),
+		dirtyDomainIDForPartition(0, 4),
+		dirtyDomainIDForPartition(5, 1),
+		dirtyDomainIDForPartition(9, 1),
+		dirtyDomainIDForPartition(17, 1),
+		dirtyDomainIDForPartition(17, 2),
+	}
+	certIDs, polIDs := mockPayloadIDsForDomains(domainIDs)
+	insertIntoDomainPayloads(ctx, t, conn, domainIDs, certIDs, polIDs)
+	insertIntoDirty(ctx, conn, "dirty", domainIDs)
+
+	expected := expectedDirtyEntries(domainIDs, certIDs, polIDs, nil)
+
+	var cursor *db.DirtyDomainEntriesCursor
+	allEntries := make([]db.KeyValuePair, 0, len(domainIDs))
+	bundleSize := uint64(3)
+
+	for bundleNum := 0; ; bundleNum++ {
+		entries, nextCursor, done, err := c.RetrieveDomainEntriesDirtyBundle(ctx, cursor, bundleSize)
+		require.NoError(t, err)
+		require.LessOrEqual(t, len(entries), int(bundleSize))
+		if len(entries) == 0 {
+			require.True(t, done)
+			break
+		}
+
+		allEntries = append(allEntries, entries...)
+		cursor = nextCursor
+		if done {
+			break
+		}
+		require.Less(t, bundleNum, len(domainIDs))
+	}
+
+	require.Len(t, allEntries, len(domainIDs))
+	kvElementsMatch(t, expected, allEntries)
+}
+
+func TestRetrieveDomainEntriesDirtyBundlePreservesMissingPayloads(t *testing.T) {
+	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelF()
+
+	config, removeF := testdb.ConfigureTestDB(t)
+	defer removeF()
+
+	conn := testdb.Connect(t, config)
+	defer conn.Close()
+
+	c := mysql.NewMysqlDBForTests(conn)
+
+	domainIDs := []common.SHA256Output{
+		dirtyDomainIDForPartition(2, 1),
+		dirtyDomainIDForPartition(2, 2),
+		dirtyDomainIDForPartition(11, 1),
+		dirtyDomainIDForPartition(19, 1),
+	}
+	certIDs, polIDs := mockPayloadIDsForDomains(domainIDs)
+
+	withPayload := []common.SHA256Output{domainIDs[0], domainIDs[2]}
+	withPayloadCerts := []common.SHA256Output{certIDs[0], certIDs[2]}
+	withPayloadPolicies := []common.SHA256Output{polIDs[0], polIDs[2]}
+	insertIntoDomainPayloads(ctx, t, conn, withPayload, withPayloadCerts, withPayloadPolicies)
+	insertIntoDirty(ctx, conn, "dirty", domainIDs)
+
+	missing := map[common.SHA256Output]struct{}{
+		domainIDs[1]: {},
+		domainIDs[3]: {},
+	}
+	expected := expectedDirtyEntries(domainIDs, certIDs, polIDs, missing)
+
+	var cursor *db.DirtyDomainEntriesCursor
+	got := make([]db.KeyValuePair, 0, len(domainIDs))
+
+	for {
+		entries, nextCursor, done, err := c.RetrieveDomainEntriesDirtyBundle(ctx, cursor, 2)
+		require.NoError(t, err)
+		require.LessOrEqual(t, len(entries), 2)
+		if len(entries) == 0 {
+			require.True(t, done)
+			break
+		}
+
+		got = append(got, entries...)
+		cursor = nextCursor
+		if done {
+			break
+		}
+	}
+
+	require.Len(t, got, len(domainIDs))
+	kvElementsMatch(t, expected, got)
+}
+
 func TestInsertDomainsIntoDirty(t *testing.T) {
 	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()
@@ -1085,6 +1193,41 @@ func mockDomainData(N int) (
 		binary.LittleEndian.PutUint64(polIDs[i][:], i+2_000_001)
 	}
 	return
+}
+
+func mockPayloadIDsForDomains(domainIDs []common.SHA256Output) (
+	certIDs []common.SHA256Output,
+	polIDs []common.SHA256Output,
+) {
+	certIDs = make([]common.SHA256Output, len(domainIDs))
+	polIDs = make([]common.SHA256Output, len(domainIDs))
+	for i, domainID := range domainIDs {
+		certIDs[i] = domainID
+		polIDs[i] = domainID
+		certIDs[i][0] ^= 0x40
+		polIDs[i][0] ^= 0x80
+	}
+	return
+}
+
+func expectedDirtyEntries(
+	domainIDs []common.SHA256Output,
+	certIDs []common.SHA256Output,
+	polIDs []common.SHA256Output,
+	missing map[common.SHA256Output]struct{},
+) []db.KeyValuePair {
+	expected := make([]db.KeyValuePair, 0, len(domainIDs))
+	for i, domainID := range domainIDs {
+		var value []byte
+		if _, ok := missing[domainID]; !ok {
+			value = common.SortIDsAndGlue([]common.SHA256Output{certIDs[i], polIDs[i]})
+		}
+		expected = append(expected, db.KeyValuePair{
+			Key:   domainID,
+			Value: value,
+		})
+	}
+	return expected
 }
 
 func dirtyDomainIDForPartition(partition, suffix byte) common.SHA256Output {

--- a/pkg/db/mysql/mysql_test.go
+++ b/pkg/db/mysql/mysql_test.go
@@ -758,6 +758,8 @@ func TestRetrieveDomainEntries(t *testing.T) {
 	require.NotSame(t, expected, joined)
 }
 
+// TestRetrieveDomainEntriesDirtyBundle checks that bundle-based dirty-domain
+// retrieval returns every expected domain-entry payload exactly once.
 func TestRetrieveDomainEntriesDirtyBundle(t *testing.T) {
 	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()
@@ -787,7 +789,7 @@ func TestRetrieveDomainEntriesDirtyBundle(t *testing.T) {
 	expected := expectedDirtyEntries(domainIDs, certIDs, polIDs, nil)
 
 	var cursor *db.DirtyDomainEntriesCursor
-	allEntries := make([]db.KeyValuePair, 0, len(domainIDs))
+	allEntries := make([]db.DomainEntryRecord, 0, len(domainIDs))
 	bundleSize := uint64(3)
 
 	for bundleNum := 0; ; bundleNum++ {
@@ -811,6 +813,9 @@ func TestRetrieveDomainEntriesDirtyBundle(t *testing.T) {
 	kvElementsMatch(t, expected, allEntries)
 }
 
+// TestRetrieveDomainEntriesDirtyBundlePreservesMissingPayloads checks that
+// missing domain_payloads rows are preserved as empty payloads instead of
+// dropping dirty domains from the returned bundle stream.
 func TestRetrieveDomainEntriesDirtyBundlePreservesMissingPayloads(t *testing.T) {
 	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()
@@ -844,7 +849,7 @@ func TestRetrieveDomainEntriesDirtyBundlePreservesMissingPayloads(t *testing.T) 
 	expected := expectedDirtyEntries(domainIDs, certIDs, polIDs, missing)
 
 	var cursor *db.DirtyDomainEntriesCursor
-	got := make([]db.KeyValuePair, 0, len(domainIDs))
+	got := make([]db.DomainEntryRecord, 0, len(domainIDs))
 
 	for {
 		entries, nextCursor, done, err := c.RetrieveDomainEntriesDirtyBundle(ctx, cursor, 2)
@@ -1001,21 +1006,21 @@ func BenchmarkRetrieveDomainEntries(b *testing.B) {
 	for i := 600_000; i <= 1_000_000; i += 100_000 {
 		str := fmt.Sprintf("querying-%d00K-", i/100_000)
 		b.Run(str+"parallel", func(b *testing.B) {
-			bdr.run(func(ctx context.Context) ([]db.KeyValuePair, error) {
+			bdr.run(func(ctx context.Context) ([]db.DomainEntryRecord, error) {
 				return c.RetrieveDirtyDomainEntriesParallel(ctx, domainIDs[:i])
 			})
 		})
 		require.Greater(b, bdr.count, 0)
 
 		b.Run(str+"sequential", func(b *testing.B) {
-			bdr.run(func(ctx context.Context) ([]db.KeyValuePair, error) {
+			bdr.run(func(ctx context.Context) ([]db.DomainEntryRecord, error) {
 				return c.RetrieveDirtyDomainEntriesSequential(ctx, domainIDs[:i])
 			})
 		})
 		require.Greater(b, bdr.count, 0)
 
 		b.Run(str+"dirty-join", func(b *testing.B) {
-			bdr.run(func(ctx context.Context) ([]db.KeyValuePair, error) {
+			bdr.run(func(ctx context.Context) ([]db.DomainEntryRecord, error) {
 				return c.RetrieveDomainEntriesDirtyOnes(ctx, 0, uint64(i))
 			})
 		})
@@ -1030,7 +1035,7 @@ type benchDomainRetrieval struct {
 }
 
 func (b *benchDomainRetrieval) run(
-	fcn func(context.Context) ([]db.KeyValuePair, error),
+	fcn func(context.Context) ([]db.DomainEntryRecord, error),
 ) {
 	b.b.ResetTimer()
 	count := 0
@@ -1040,7 +1045,7 @@ func (b *benchDomainRetrieval) run(
 		require.NotEmpty(b.b, kv)
 		// Do something with the key values to avoid compiler dead code optimization.
 		for _, kv := range kv {
-			count += len(kv.Value)
+			count += len(kv.Payload)
 		}
 	}
 	b.count = count
@@ -1148,16 +1153,17 @@ func getAllCertsTable(ctx context.Context, t tests.T, conn db.Conn) (
 	return
 }
 
-// kvElementsMatch acts as require.ElementsMatch, but faster (no reflection).
-func kvElementsMatch(t tests.T, expected, got []db.KeyValuePair, args ...any) {
+// kvElementsMatch compares domain-entry records without using reflection so the
+// large DB-backed tests stay cheap.
+func kvElementsMatch(t tests.T, expected, got []db.DomainEntryRecord, args ...any) {
 	t.Helper()
 	A := make(map[common.SHA256Output][]byte)
 	for _, x := range expected {
-		A[x.Key] = x.Value
+		A[x.DomainID] = x.Payload
 	}
 	B := make(map[common.SHA256Output][]byte)
 	for _, x := range got {
-		B[x.Key] = x.Value
+		B[x.DomainID] = x.Payload
 	}
 
 	if len(A) != len(B) {
@@ -1215,16 +1221,16 @@ func expectedDirtyEntries(
 	certIDs []common.SHA256Output,
 	polIDs []common.SHA256Output,
 	missing map[common.SHA256Output]struct{},
-) []db.KeyValuePair {
-	expected := make([]db.KeyValuePair, 0, len(domainIDs))
+) []db.DomainEntryRecord {
+	expected := make([]db.DomainEntryRecord, 0, len(domainIDs))
 	for i, domainID := range domainIDs {
 		var value []byte
 		if _, ok := missing[domainID]; !ok {
 			value = common.SortIDsAndGlue([]common.SHA256Output{certIDs[i], polIDs[i]})
 		}
-		expected = append(expected, db.KeyValuePair{
-			Key:   domainID,
-			Value: value,
+		expected = append(expected, db.DomainEntryRecord{
+			DomainID: domainID,
+			Payload:  value,
 		})
 	}
 	return expected

--- a/pkg/db/mysql/smt.go
+++ b/pkg/db/mysql/smt.go
@@ -59,7 +59,8 @@ func (c *mysqlDB) DeleteTreeNodes(ctx context.Context, keys []common.SHA256Outpu
 	return int(n), nil
 }
 
-func (c *mysqlDB) UpdateTreeNodes(ctx context.Context, keyValuePairs []*db.KeyValuePair) (int, error) {
+// UpdateTreeNodes persists SMT node records into the tree table.
+func (c *mysqlDB) UpdateTreeNodes(ctx context.Context, keyValuePairs []*db.TreeNodeRecord) (int, error) {
 	if len(keyValuePairs) == 0 {
 		return 0, nil
 	}

--- a/pkg/mapserver/trie/trie.go
+++ b/pkg/mapserver/trie/trie.go
@@ -9,8 +9,18 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"runtime"
 	"sync"
+	"sync/atomic"
 )
+
+const minParallelUpdateKeys = 4096
+
+var maxParallelUpdateGoroutines = func() int {
+	// 1<= n <= 128
+	n := min(128, 4*runtime.GOMAXPROCS(0))
+	return n
+}()
 
 // Trie is a modified sparse Merkle tree.
 // Instead of storing values at the leaves of the tree,
@@ -44,6 +54,14 @@ type Trie struct {
 	pastTries [][]byte
 	// atomicUpdate, commit all the changes made by intermediate update calls
 	atomicUpdate bool
+	// updateSem enforces the recursive parallelism cap. A branch only runs in
+	// its own goroutine if it can acquire one slot; otherwise it is processed
+	// synchronously by the caller.
+	updateSem chan struct{}
+	// These counters are test-only telemetry. They do not enforce the worker
+	// cap; they only record the peak number of active spawned workers.
+	activeUpdateWorkers int32
+	maxActiveWorkers    int32
 }
 
 // NewSMT creates a new SMT given a keySize and a hash function.
@@ -52,6 +70,7 @@ func NewTrie(root []byte, hash func(data ...[]byte) []byte, store DBConn) (*Trie
 		hash:       hash,
 		TrieHeight: len(hash([]byte("height"))) * 8, // hash any string to get output length
 		counterOn:  false,
+		updateSem:  make(chan struct{}, maxParallelUpdateGoroutines),
 	}
 	var err error
 	s.db, err = NewCacheDB(store)
@@ -278,8 +297,12 @@ func (s *Trie) updateLeft(ctx context.Context, lNode, rNode, root []byte, keys, 
 func (s *Trie) updateParallel(ctx context.Context, lNode, rNode, root []byte, lKeys, rKeys, lValues, rValues, batch [][]byte, iBatch, height int, ch chan<- (mResult)) {
 	lch := make(chan mResult, 1)
 	rch := make(chan mResult, 1)
-	go s.update(ctx, lNode, lKeys, lValues, batch, 2*iBatch+1, height-1, lch)
-	go s.update(ctx, rNode, rKeys, rValues, batch, 2*iBatch+2, height-1, rch)
+	if !s.trySpawnUpdateWorker(ctx, lNode, lKeys, lValues, batch, 2*iBatch+1, height-1, lch) {
+		s.update(ctx, lNode, lKeys, lValues, batch, 2*iBatch+1, height-1, lch)
+	}
+	if !s.trySpawnUpdateWorker(ctx, rNode, rKeys, rValues, batch, 2*iBatch+2, height-1, rch) {
+		s.update(ctx, rNode, rKeys, rValues, batch, 2*iBatch+2, height-1, rch)
+	}
 	lResult := <-lch
 	rResult := <-rch
 	if lResult.err != nil {
@@ -299,6 +322,46 @@ func (s *Trie) updateParallel(ctx context.Context, lNode, rNode, root []byte, lK
 	}
 	node := s.interiorHash(lResult.update, rResult.update, root, batch, iBatch, height)
 	ch <- mResult{node, false, nil}
+}
+
+func (s *Trie) trySpawnUpdateWorker(
+	ctx context.Context,
+	root []byte,
+	keys, values, batch [][]byte,
+	iBatch, height int,
+	ch chan<- mResult,
+) bool {
+	if len(keys) < minParallelUpdateKeys || s.updateSem == nil {
+		return false
+	}
+
+	select {
+	case s.updateSem <- struct{}{}:
+		current := atomic.AddInt32(&s.activeUpdateWorkers, 1)
+		s.recordMaxActiveWorkers(current)
+		go func() {
+			defer func() {
+				atomic.AddInt32(&s.activeUpdateWorkers, -1)
+				<-s.updateSem
+			}()
+			s.update(ctx, root, keys, values, batch, iBatch, height, ch)
+		}()
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *Trie) recordMaxActiveWorkers(current int32) {
+	for {
+		maxSeen := atomic.LoadInt32(&s.maxActiveWorkers)
+		if current <= maxSeen {
+			return
+		}
+		if atomic.CompareAndSwapInt32(&s.maxActiveWorkers, maxSeen, current) {
+			return
+		}
+	}
 }
 
 // deleteOldNode deletes an old node that has been updated
@@ -593,7 +656,9 @@ func (s *Trie) GetLiveCacheSize() int {
 }
 
 func (s *Trie) ResetLiveCache() {
+	s.db.liveMux.Lock()
 	s.db.liveCache = make(map[Hash][][]byte)
+	s.db.liveMux.Unlock()
 }
 
 // parseBatch decodes the byte data into a slice of nodes and bitmap

--- a/pkg/mapserver/trie/trie_cache.go
+++ b/pkg/mapserver/trie/trie_cache.go
@@ -40,7 +40,7 @@ type CacheDB struct {
 type DBConn interface {
 	Close() error
 	RetrieveTreeNode(ctx context.Context, key common.SHA256Output) ([]byte, error)
-	UpdateTreeNodes(ctx context.Context, keyValuePairs []*db.KeyValuePair) (int, error)
+	UpdateTreeNodes(ctx context.Context, keyValuePairs []*db.TreeNodeRecord) (int, error)
 	DeleteTreeNodes(ctx context.Context, keys []common.SHA256Output) (int, error)
 }
 
@@ -58,13 +58,13 @@ func NewCacheDB(store DBConn) (*CacheDB, error) {
 // commitChangesToDB stores the updated nodes to disk.
 func (cacheDB *CacheDB) commitChangesToDB(ctx context.Context) error {
 	// prepare value to store
-	updatesToDB := []*db.KeyValuePair{}
+	updatesToDB := []*db.TreeNodeRecord{}
 	keysToDelete := []common.SHA256Output{}
 
 	// get nodes from update map
 	cacheDB.updatedMux.Lock()
 	for k, v := range cacheDB.updatedNodes {
-		updatesToDB = append(updatesToDB, &db.KeyValuePair{Key: k, Value: serializeBatch(v)})
+		updatesToDB = append(updatesToDB, &db.TreeNodeRecord{Key: k, Value: serializeBatch(v)})
 	}
 	cacheDB.updatedNodes = make(map[Hash][][]byte)
 	cacheDB.updatedMux.Unlock()

--- a/pkg/mapserver/trie/trie_test.go
+++ b/pkg/mapserver/trie/trie_test.go
@@ -8,6 +8,7 @@ package trie
 import (
 	"context"
 	"math/rand"
+	"runtime"
 	"sort"
 	"testing"
 	"time"
@@ -201,6 +202,33 @@ func TestTrieUpdateAndDelete(t *testing.T) {
 	require.True(t, isShortcut)
 	require.Equal(t, key1, k[:HashLength])
 	require.Equal(t, values[1], v[:HashLength])
+
+	err = smt.Close()
+	require.NoError(t, err)
+}
+
+// TestTrieUpdateParallelismIsBounded checks that large trie updates respect the
+// internal goroutine cap instead of recursively spawning unbounded workers.
+func TestTrieUpdateParallelismIsBounded(t *testing.T) {
+	rand.Seed(1)
+	ctx, cancelF := context.WithTimeout(context.Background(), time.Minute)
+	defer cancelF()
+
+	config, removeF := testdb.ConfigureTestDB(t)
+	defer removeF()
+
+	conn := testdb.Connect(t, config)
+
+	smt, err := NewTrie(nil, common.SHA256Hash, conn)
+	require.NoError(t, err)
+
+	keys := getRandomData(t, 8192)
+	values := getRandomData(t, 8192)
+	_, err = smt.Update(ctx, keys, values)
+	require.NoError(t, err)
+
+	require.LessOrEqual(t, int(smt.maxActiveWorkers), maxParallelUpdateGoroutines)
+	require.LessOrEqual(t, runtime.NumGoroutine(), maxParallelUpdateGoroutines+32)
 
 	err = smt.Close()
 	require.NoError(t, err)

--- a/pkg/mapserver/updater/smt_correctness_test.go
+++ b/pkg/mapserver/updater/smt_correctness_test.go
@@ -178,6 +178,37 @@ func TestUpdateSMT_BundleSizeDoesNotAffectRoot(t *testing.T) {
 	}
 }
 
+// TestUpdateSMTFromKeyValues_ResetsLiveCacheAfterEachCommit checks that each
+// committed SMT bundle clears the trie live cache so memory does not accumulate
+// across successive bundles.
+func TestUpdateSMTFromKeyValues_ResetsLiveCacheAfterEachCommit(t *testing.T) {
+	ctx, conn := newSMTTestConn(t, "cache-reset")
+	populateScenario(t, ctx, conn, []smtDomainSpec{
+		{name: "cache-a.example.com", kind: smtCertsAndPolicies, seed: 601},
+		{name: "cache-b.example.com", kind: smtCertsAndPolicies, seed: 602},
+	})
+	require.NoError(t, CoalescePayloadsForDirtyDomains(ctx, conn))
+
+	rootBytes, err := loadRoot(ctx, conn)
+	require.NoError(t, err)
+
+	smtTrie, err := trie.NewTrie(rootBytes, common.SHA256Hash, conn)
+	require.NoError(t, err)
+	smtTrie.CacheHeightLimit = 32
+
+	var cursor *dbpkg.DirtyDomainEntriesCursor
+	for i := 0; i < 2; i++ {
+		entries, nextCursor, _, err := conn.RetrieveDomainEntriesDirtyBundle(ctx, cursor, 1)
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+
+		require.NoError(t, updateSMTfromKeyValues(ctx, smtTrie, entries))
+		require.Zero(t, smtTrie.GetLiveCacheSize())
+
+		cursor = nextCursor
+	}
+}
+
 // TestUpdateSMT_PersistsReloadableRoot checks that the root saved by UpdateSMT can be reloaded by
 // a fresh responder instance and still serves valid proofs without any further updates.
 func TestUpdateSMT_PersistsReloadableRoot(t *testing.T) {

--- a/pkg/mapserver/updater/smt_correctness_test.go
+++ b/pkg/mapserver/updater/smt_correctness_test.go
@@ -162,7 +162,7 @@ func TestUpdateSMTFromKeyValues_ResetsLiveCacheAfterEachCommit(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, entries, 1)
 
-		require.NoError(t, updateSMTfromKeyValues(ctx, smtTrie, entries))
+		require.NoError(t, updateSMTFromDomainEntries(ctx, smtTrie, entries))
 		require.Zero(t, smtTrie.GetLiveCacheSize())
 
 		cursor = nextCursor

--- a/pkg/mapserver/updater/smt_correctness_test.go
+++ b/pkg/mapserver/updater/smt_correctness_test.go
@@ -108,46 +108,6 @@ func TestUpdateSMT_EmptyDirty_NoRootChange(t *testing.T) {
 	})
 }
 
-// TestUpdateSMT_FromDirtyAndFromDomains_ProduceSameRoot checks that the dirty-table function and
-// the explicit-domain function produce the same saved root and valid proofs for the same
-// logical dataset.
-func TestUpdateSMT_FromDirtyAndFromDomains_ProduceSameRoot(t *testing.T) {
-	specs := []smtDomainSpec{
-		{name: "cert-only.example.com", kind: smtCertOnly, seed: 101},
-		{name: "policy-only.example.com", kind: smtPolicyOnly, seed: 102},
-		{name: "mixed.example.com", kind: smtCertsAndPolicies, seed: 103},
-	}
-
-	ctxA, connA := newSMTTestConn(t, "domains-path")
-	expectedA := populateScenario(t, ctxA, connA, specs)
-	require.NoError(t, CoalescePayloadsForDirtyDomains(ctxA, connA))
-	rootA := runSMTPath(t, ctxA, connA, "domains", 2)
-
-	ctxB, connB := newSMTTestConn(t, "dirty-path")
-	expectedB := populateScenario(t, ctxB, connB, specs)
-	require.NoError(t, CoalescePayloadsForDirtyDomains(ctxB, connB))
-	rootB := runSMTPath(t, ctxB, connB, "dirty", 2)
-
-	require.Equal(t, rootA, rootB)
-	require.Equal(t, rootA, *loadSavedRoot(t, ctxA, connA))
-	require.Equal(t, rootB, *loadSavedRoot(t, ctxB, connB))
-
-	assertProofsValid(t, ctxA, connA,
-		smtProofCheck{domain: "cert-only.example.com", present: true},
-		smtProofCheck{domain: "policy-only.example.com", present: true},
-		smtProofCheck{domain: "mixed.example.com", present: true},
-		smtProofCheck{domain: "absent.example.com", present: false},
-	)
-	assertProofsValid(t, ctxB, connB,
-		smtProofCheck{domain: "cert-only.example.com", present: true},
-		smtProofCheck{domain: "policy-only.example.com", present: true},
-		smtProofCheck{domain: "mixed.example.com", present: true},
-		smtProofCheck{domain: "absent.example.com", present: false},
-	)
-	assertLeafEntryMatches(t, ctxA, connA, expectedA["mixed.example.com"])
-	assertLeafEntryMatches(t, ctxB, connB, expectedB["mixed.example.com"])
-}
-
 // TestUpdateSMT_BundleSizeDoesNotAffectRoot checks that splitting the same dirty workload into
 // different bundle sizes does not change the final SMT root or proof validity.
 func TestUpdateSMT_BundleSizeDoesNotAffectRoot(t *testing.T) {
@@ -164,7 +124,7 @@ func TestUpdateSMT_BundleSizeDoesNotAffectRoot(t *testing.T) {
 		populateScenario(t, ctx, conn, specs)
 		require.NoError(t, CoalescePayloadsForDirtyDomains(ctx, conn))
 
-		root := runSMTPath(t, ctx, conn, "dirty", bundleSize)
+		root := runDirtySMTPath(t, ctx, conn, bundleSize)
 		roots = append(roots, root)
 
 		assertProofsValid(t, ctx, conn,
@@ -384,13 +344,13 @@ func TestUpdateSMT_DirtyOrderingDoesNotAffectRoot(t *testing.T) {
 	populateScenario(t, ctxA, connA, specs)
 	reorderDirtyDomains(t, ctxA, connA, reversed)
 	require.NoError(t, CoalescePayloadsForDirtyDomains(ctxA, connA))
-	rootA := runSMTPath(t, ctxA, connA, "domains", len(specs)+2)
+	rootA := runDirtySMTPath(t, ctxA, connA, len(specs)+2)
 
 	ctxB, connB := newSMTTestConn(t, "order-shuffled")
 	populateScenario(t, ctxB, connB, specs)
 	reorderDirtyDomains(t, ctxB, connB, shuffled)
 	require.NoError(t, CoalescePayloadsForDirtyDomains(ctxB, connB))
-	rootB := runSMTPath(t, ctxB, connB, "domains", len(specs)+2)
+	rootB := runDirtySMTPath(t, ctxB, connB, len(specs)+2)
 
 	require.Equal(t, rootA, rootB)
 	require.Equal(t, rootA, *loadSavedRoot(t, ctxA, connA))
@@ -472,11 +432,10 @@ func populateScenario(
 	return expected
 }
 
-func runSMTPath(
+func runDirtySMTPath(
 	t *testing.T,
 	ctx context.Context,
 	conn dbpkg.Conn,
-	path string,
 	bundleSize int,
 ) common.SHA256Output {
 	t.Helper()
@@ -488,18 +447,8 @@ func runSMTPath(
 	require.NoError(t, err)
 	smtTrie.CacheHeightLimit = 32
 
-	switch path {
-	case "domains":
-		domains, err := conn.RetrieveDirtyDomains(ctx)
-		require.NoError(t, err)
-		err = updateSMTfromDomains(ctx, conn, smtTrie, domains, bundleSize)
-		require.NoError(t, err)
-	case "dirty":
-		err = updateSMTfromDirty(ctx, conn, smtTrie, uint64(bundleSize))
-		require.NoError(t, err)
-	default:
-		require.FailNow(t, fmt.Sprintf("unknown SMT path %q", path))
-	}
+	err = updateSMTfromDirty(ctx, conn, smtTrie, uint64(bundleSize))
+	require.NoError(t, err)
 
 	require.NotNil(t, smtTrie.Root)
 

--- a/pkg/mapserver/updater/smt_correctness_test.go
+++ b/pkg/mapserver/updater/smt_correctness_test.go
@@ -1,0 +1,570 @@
+package updater
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"path/filepath"
+	"testing"
+	"time"
+
+	ctx509 "github.com/google/certificate-transparency-go/x509"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netsec-ethz/fpki/pkg/common"
+	dbpkg "github.com/netsec-ethz/fpki/pkg/db"
+	mapcommon "github.com/netsec-ethz/fpki/pkg/mapserver/common"
+	"github.com/netsec-ethz/fpki/pkg/mapserver/prover"
+	"github.com/netsec-ethz/fpki/pkg/mapserver/responder"
+	"github.com/netsec-ethz/fpki/pkg/mapserver/trie"
+	"github.com/netsec-ethz/fpki/pkg/tests/random"
+	"github.com/netsec-ethz/fpki/pkg/tests/testdb"
+	"github.com/netsec-ethz/fpki/pkg/util"
+)
+
+type smtDomainKind int
+
+const (
+	smtCertOnly smtDomainKind = iota
+	smtPolicyOnly
+	smtCertsAndPolicies
+)
+
+type smtDomainSpec struct {
+	name string
+	kind smtDomainKind
+	seed int64
+}
+
+type smtExpectedDomain struct {
+	name      string
+	certIDs   []common.SHA256Output
+	policyIDs []common.SHA256Output
+}
+
+type smtProofCheck struct {
+	domain  string
+	present bool
+}
+
+type namedTest struct {
+	*testing.T
+	name string
+}
+
+func (t namedTest) Name() string {
+	return t.name
+}
+
+func (e smtExpectedDomain) certBytes(t *testing.T) ([]byte, common.SHA256Output) {
+	t.Helper()
+	return glueSortedIDsAndComputeItsID(e.certIDs)
+}
+
+func (e smtExpectedDomain) policyBytes(t *testing.T) ([]byte, common.SHA256Output) {
+	t.Helper()
+	return glueSortedIDsAndComputeItsID(e.policyIDs)
+}
+
+// TestUpdateSMT_EmptyDirty_NoRootChange checks that UpdateSMT is a no-op when there are no dirty
+// domains, both when the root is empty and when a previously computed root already exists.
+func TestUpdateSMT_EmptyDirty_NoRootChange(t *testing.T) {
+	t.Run("nil-root", func(t *testing.T) {
+		ctx, conn := newSMTTestConn(t, "nil-root")
+
+		err := UpdateSMT(ctx, conn)
+		require.NoError(t, err)
+
+		root := loadSavedRoot(t, ctx, conn)
+		require.Nil(t, root)
+
+		assertProofsValid(t, ctx, conn, smtProofCheck{domain: "absent.example.com", present: false})
+	})
+
+	t.Run("existing-root", func(t *testing.T) {
+		ctx, conn := newSMTTestConn(t, "existing-root")
+		populateScenario(t, ctx, conn, []smtDomainSpec{
+			{name: "existing-root.example.com", kind: smtCertsAndPolicies, seed: 42},
+		})
+		require.NoError(t, CoalescePayloadsForDirtyDomains(ctx, conn))
+		require.NoError(t, UpdateSMT(ctx, conn))
+		original := loadSavedRoot(t, ctx, conn)
+		require.NotNil(t, original)
+		require.NoError(t, conn.CleanupDirty(ctx))
+
+		err := UpdateSMT(ctx, conn)
+		require.NoError(t, err)
+
+		root := loadSavedRoot(t, ctx, conn)
+		require.NotNil(t, root)
+		require.Equal(t, *original, *root)
+
+		assertProofsValid(t, ctx, conn,
+			smtProofCheck{domain: "existing-root.example.com", present: true},
+			smtProofCheck{domain: "absent.example.com", present: false},
+		)
+	})
+}
+
+// TestUpdateSMT_FromDirtyAndFromDomains_ProduceSameRoot checks that the dirty-table function and
+// the explicit-domain function produce the same saved root and valid proofs for the same
+// logical dataset.
+func TestUpdateSMT_FromDirtyAndFromDomains_ProduceSameRoot(t *testing.T) {
+	specs := []smtDomainSpec{
+		{name: "cert-only.example.com", kind: smtCertOnly, seed: 101},
+		{name: "policy-only.example.com", kind: smtPolicyOnly, seed: 102},
+		{name: "mixed.example.com", kind: smtCertsAndPolicies, seed: 103},
+	}
+
+	ctxA, connA := newSMTTestConn(t, "domains-path")
+	expectedA := populateScenario(t, ctxA, connA, specs)
+	require.NoError(t, CoalescePayloadsForDirtyDomains(ctxA, connA))
+	rootA := runSMTPath(t, ctxA, connA, "domains", 2)
+
+	ctxB, connB := newSMTTestConn(t, "dirty-path")
+	expectedB := populateScenario(t, ctxB, connB, specs)
+	require.NoError(t, CoalescePayloadsForDirtyDomains(ctxB, connB))
+	rootB := runSMTPath(t, ctxB, connB, "dirty", 2)
+
+	require.Equal(t, rootA, rootB)
+	require.Equal(t, rootA, *loadSavedRoot(t, ctxA, connA))
+	require.Equal(t, rootB, *loadSavedRoot(t, ctxB, connB))
+
+	assertProofsValid(t, ctxA, connA,
+		smtProofCheck{domain: "cert-only.example.com", present: true},
+		smtProofCheck{domain: "policy-only.example.com", present: true},
+		smtProofCheck{domain: "mixed.example.com", present: true},
+		smtProofCheck{domain: "absent.example.com", present: false},
+	)
+	assertProofsValid(t, ctxB, connB,
+		smtProofCheck{domain: "cert-only.example.com", present: true},
+		smtProofCheck{domain: "policy-only.example.com", present: true},
+		smtProofCheck{domain: "mixed.example.com", present: true},
+		smtProofCheck{domain: "absent.example.com", present: false},
+	)
+	assertLeafEntryMatches(t, ctxA, connA, expectedA["mixed.example.com"])
+	assertLeafEntryMatches(t, ctxB, connB, expectedB["mixed.example.com"])
+}
+
+// TestUpdateSMT_BundleSizeDoesNotAffectRoot checks that splitting the same dirty workload into
+// different bundle sizes does not change the final SMT root or proof validity.
+func TestUpdateSMT_BundleSizeDoesNotAffectRoot(t *testing.T) {
+	specs := []smtDomainSpec{
+		{name: "bundle-cert.example.com", kind: smtCertOnly, seed: 201},
+		{name: "bundle-policy.example.com", kind: smtPolicyOnly, seed: 202},
+		{name: "bundle-mixed.example.com", kind: smtCertsAndPolicies, seed: 203},
+	}
+
+	bundleSizes := []int{1, 2, len(specs) + 5}
+	roots := make([]common.SHA256Output, 0, len(bundleSizes))
+	for _, bundleSize := range bundleSizes {
+		ctx, conn := newSMTTestConn(t, fmt.Sprintf("bundle-%d", bundleSize))
+		populateScenario(t, ctx, conn, specs)
+		require.NoError(t, CoalescePayloadsForDirtyDomains(ctx, conn))
+
+		root := runSMTPath(t, ctx, conn, "dirty", bundleSize)
+		roots = append(roots, root)
+
+		assertProofsValid(t, ctx, conn,
+			smtProofCheck{domain: "bundle-mixed.example.com", present: true},
+			smtProofCheck{domain: "bundle-absent.example.com", present: false},
+		)
+	}
+
+	for i := 1; i < len(roots); i++ {
+		require.Equal(t, roots[0], roots[i])
+	}
+}
+
+// TestUpdateSMT_PersistsReloadableRoot checks that the root saved by UpdateSMT can be reloaded by
+// a fresh responder instance and still serves valid proofs without any further updates.
+func TestUpdateSMT_PersistsReloadableRoot(t *testing.T) {
+	ctx, conn := newSMTTestConn(t, "persist")
+	expected := populateScenario(t, ctx, conn, []smtDomainSpec{
+		{name: "persist-cert.example.com", kind: smtCertOnly, seed: 301},
+		{name: "persist-policy.example.com", kind: smtPolicyOnly, seed: 302},
+		{name: "persist-mixed.example.com", kind: smtCertsAndPolicies, seed: 303},
+	})
+
+	require.NoError(t, CoalescePayloadsForDirtyDomains(ctx, conn))
+	require.NoError(t, UpdateSMT(ctx, conn))
+
+	savedRoot := loadSavedRoot(t, ctx, conn)
+	require.NotNil(t, savedRoot)
+
+	loadedRoot, err := conn.LoadRoot(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, loadedRoot)
+	require.Equal(t, *savedRoot, *loadedRoot)
+
+	assertProofsValid(t, ctx, conn,
+		smtProofCheck{domain: "persist-cert.example.com", present: true},
+		smtProofCheck{domain: "persist-policy.example.com", present: true},
+		smtProofCheck{domain: "persist-absent.example.com", present: false},
+	)
+	assertLeafEntryMatches(t, ctx, conn, expected["persist-cert.example.com"])
+	assertLeafEntryMatches(t, ctx, conn, expected["persist-policy.example.com"])
+}
+
+// TestUpdateSMT_IncrementalUpdateMatchesFreshBuild checks that applying a second wave of changes
+// incrementally yields the same final root and proofs as rebuilding from the final state directly.
+func TestUpdateSMT_IncrementalUpdateMatchesFreshBuild(t *testing.T) {
+	initialSpecs := []smtDomainSpec{
+		{name: "unchanged.example.com", kind: smtCertOnly, seed: 401},
+		{name: "modified.example.com", kind: smtPolicyOnly, seed: 402},
+		{name: "other.example.com", kind: smtCertsAndPolicies, seed: 403},
+	}
+	finalSpecs := []smtDomainSpec{
+		{name: "unchanged.example.com", kind: smtCertOnly, seed: 401},
+		{name: "modified.example.com", kind: smtCertsAndPolicies, seed: 502},
+		{name: "other.example.com", kind: smtCertsAndPolicies, seed: 403},
+		{name: "new.example.com", kind: smtPolicyOnly, seed: 404},
+	}
+
+	ctxInc, connInc := newSMTTestConn(t, "incremental")
+	populateScenario(t, ctxInc, connInc, initialSpecs)
+	require.NoError(t, CoalescePayloadsForDirtyDomains(ctxInc, connInc))
+	require.NoError(t, UpdateSMT(ctxInc, connInc))
+	require.NoError(t, connInc.CleanupDirty(ctxInc))
+
+	modifiedID := common.SHA256Hash32Bytes([]byte("modified.example.com"))
+	_, err := connInc.DB().ExecContext(ctxInc, "DELETE FROM domain_certs WHERE domain_id = ?", modifiedID[:])
+	require.NoError(t, err)
+	_, err = connInc.DB().ExecContext(ctxInc, "DELETE FROM domain_policies WHERE domain_id = ?", modifiedID[:])
+	require.NoError(t, err)
+	require.NoError(t, connInc.InsertDomainsIntoDirty(ctxInc, []common.SHA256Output{modifiedID}))
+
+	modifiedExpected := populateScenario(t, ctxInc, connInc, []smtDomainSpec{
+		{name: "modified.example.com", kind: smtCertsAndPolicies, seed: 502},
+		{name: "new.example.com", kind: smtPolicyOnly, seed: 404},
+	})
+	require.NoError(t, CoalescePayloadsForDirtyDomains(ctxInc, connInc))
+	require.NoError(t, UpdateSMT(ctxInc, connInc))
+	incrementalRoot := loadSavedRoot(t, ctxInc, connInc)
+	require.NotNil(t, incrementalRoot)
+
+	ctxFresh, connFresh := newSMTTestConn(t, "fresh")
+	freshExpected := populateScenario(t, ctxFresh, connFresh, finalSpecs)
+	require.NoError(t, CoalescePayloadsForDirtyDomains(ctxFresh, connFresh))
+	require.NoError(t, UpdateSMT(ctxFresh, connFresh))
+	freshRoot := loadSavedRoot(t, ctxFresh, connFresh)
+	require.NotNil(t, freshRoot)
+
+	require.Equal(t, *incrementalRoot, *freshRoot)
+	assertProofsValid(t, ctxInc, connInc,
+		smtProofCheck{domain: "modified.example.com", present: true},
+		smtProofCheck{domain: "unchanged.example.com", present: true},
+		smtProofCheck{domain: "new.example.com", present: true},
+		smtProofCheck{domain: "absent.example.com", present: false},
+	)
+	assertProofsValid(t, ctxFresh, connFresh,
+		smtProofCheck{domain: "modified.example.com", present: true},
+		smtProofCheck{domain: "unchanged.example.com", present: true},
+		smtProofCheck{domain: "new.example.com", present: true},
+		smtProofCheck{domain: "absent.example.com", present: false},
+	)
+	assertLeafEntryMatches(t, ctxInc, connInc, modifiedExpected["modified.example.com"])
+	assertLeafEntryMatches(t, ctxFresh, connFresh, freshExpected["modified.example.com"])
+}
+
+// TestUpdateSMT_RemovesStaleDomainFromTrie checks that a domain removed from the coalesced payloads
+// is removed from the SMT as well and turns into a valid proof of absence.
+func TestUpdateSMT_RemovesStaleDomainFromTrie(t *testing.T) {
+	ctx, conn := newSMTTestConn(t, "stale")
+	populateScenario(t, ctx, conn, []smtDomainSpec{
+		{name: "stale.example.com", kind: smtCertsAndPolicies, seed: 601},
+	})
+
+	require.NoError(t, CoalescePayloadsForDirtyDomains(ctx, conn))
+	require.NoError(t, UpdateSMT(ctx, conn))
+	beforeRoot := loadSavedRoot(t, ctx, conn)
+	require.NotNil(t, beforeRoot)
+	assertProofsValid(t, ctx, conn, smtProofCheck{domain: "stale.example.com", present: true})
+
+	require.NoError(t, conn.CleanupDirty(ctx))
+	domainID := common.SHA256Hash32Bytes([]byte("stale.example.com"))
+	_, err := conn.DB().ExecContext(ctx, "DELETE FROM domain_certs WHERE domain_id = ?", domainID[:])
+	require.NoError(t, err)
+	_, err = conn.DB().ExecContext(ctx, "DELETE FROM domain_policies WHERE domain_id = ?", domainID[:])
+	require.NoError(t, err)
+	require.NoError(t, conn.InsertDomainsIntoDirty(ctx, []common.SHA256Output{domainID}))
+
+	require.NoError(t, CoalescePayloadsForDirtyDomains(ctx, conn))
+	require.NoError(t, UpdateSMT(ctx, conn))
+	afterRoot := loadSavedRoot(t, ctx, conn)
+	require.NotNil(t, afterRoot)
+	require.NotEqual(t, *beforeRoot, *afterRoot)
+
+	assertProofsValid(t, ctx, conn, smtProofCheck{domain: "stale.example.com", present: false})
+}
+
+// TestUpdateSMT_MixedCertsPoliciesProofContents checks that proofs expose the expected cert-only,
+// policy-only, and mixed payload contents after an SMT update.
+func TestUpdateSMT_MixedCertsPoliciesProofContents(t *testing.T) {
+	ctx, conn := newSMTTestConn(t, "proof-contents")
+	expected := populateScenario(t, ctx, conn, []smtDomainSpec{
+		{name: "proof-cert.example.com", kind: smtCertOnly, seed: 701},
+		{name: "proof-policy.example.com", kind: smtPolicyOnly, seed: 702},
+		{name: "proof-mixed.example.com", kind: smtCertsAndPolicies, seed: 703},
+	})
+
+	require.NoError(t, CoalescePayloadsForDirtyDomains(ctx, conn))
+	require.NoError(t, UpdateSMT(ctx, conn))
+
+	assertLeafEntryMatches(t, ctx, conn, expected["proof-cert.example.com"])
+	assertLeafEntryMatches(t, ctx, conn, expected["proof-policy.example.com"])
+	assertLeafEntryMatches(t, ctx, conn, expected["proof-mixed.example.com"])
+
+	certLeaf := getLeafProof(t, ctx, conn, "proof-cert.example.com")
+	require.Empty(t, certLeaf.DomainEntry.PolicyIDs)
+
+	policyLeaf := getLeafProof(t, ctx, conn, "proof-policy.example.com")
+	require.Empty(t, policyLeaf.DomainEntry.CertIDs)
+
+	mixedLeaf := getLeafProof(t, ctx, conn, "proof-mixed.example.com")
+	allIDs := append(common.BytesToIDs(mixedLeaf.DomainEntry.CertIDs),
+		common.BytesToIDs(mixedLeaf.DomainEntry.PolicyIDs)...)
+	require.NotEmpty(t, allIDs)
+	require.Contains(t, allIDs, expected["proof-mixed.example.com"].certIDs[0])
+}
+
+// TestUpdateSMT_DirtyOrderingDoesNotAffectRoot checks that different insertion orders in the dirty
+// table do not affect the final SMT root or the validity of representative proofs.
+func TestUpdateSMT_DirtyOrderingDoesNotAffectRoot(t *testing.T) {
+	specs := []smtDomainSpec{
+		{name: "order-a.example.com", kind: smtCertOnly, seed: 801},
+		{name: "order-b.example.com", kind: smtPolicyOnly, seed: 802},
+		{name: "order-c.example.com", kind: smtCertsAndPolicies, seed: 803},
+	}
+	reversed := []common.SHA256Output{
+		common.SHA256Hash32Bytes([]byte("order-c.example.com")),
+		common.SHA256Hash32Bytes([]byte("order-b.example.com")),
+		common.SHA256Hash32Bytes([]byte("order-a.example.com")),
+	}
+	shuffled := []common.SHA256Output{
+		common.SHA256Hash32Bytes([]byte("order-b.example.com")),
+		common.SHA256Hash32Bytes([]byte("order-c.example.com")),
+		common.SHA256Hash32Bytes([]byte("order-a.example.com")),
+	}
+
+	ctxA, connA := newSMTTestConn(t, "order-reversed")
+	populateScenario(t, ctxA, connA, specs)
+	reorderDirtyDomains(t, ctxA, connA, reversed)
+	require.NoError(t, CoalescePayloadsForDirtyDomains(ctxA, connA))
+	rootA := runSMTPath(t, ctxA, connA, "domains", len(specs)+2)
+
+	ctxB, connB := newSMTTestConn(t, "order-shuffled")
+	populateScenario(t, ctxB, connB, specs)
+	reorderDirtyDomains(t, ctxB, connB, shuffled)
+	require.NoError(t, CoalescePayloadsForDirtyDomains(ctxB, connB))
+	rootB := runSMTPath(t, ctxB, connB, "domains", len(specs)+2)
+
+	require.Equal(t, rootA, rootB)
+	require.Equal(t, rootA, *loadSavedRoot(t, ctxA, connA))
+	require.Equal(t, rootB, *loadSavedRoot(t, ctxB, connB))
+
+	assertProofsValid(t, ctxA, connA,
+		smtProofCheck{domain: "order-a.example.com", present: true},
+		smtProofCheck{domain: "order-absent.example.com", present: false},
+	)
+	assertProofsValid(t, ctxB, connB,
+		smtProofCheck{domain: "order-a.example.com", present: true},
+		smtProofCheck{domain: "order-absent.example.com", present: false},
+	)
+}
+
+func newSMTTestConn(t *testing.T, suffix string) (context.Context, dbpkg.Conn) {
+	t.Helper()
+
+	sum := common.SHA256Hash32Bytes([]byte(t.Name() + "_" + suffix))
+	tb := namedTest{T: t, name: "smt_" + hex.EncodeToString(sum[:8])}
+	config, removeF := testdb.ConfigureTestDB(tb)
+	t.Cleanup(removeF)
+
+	conn := testdb.Connect(tb, config)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	ctx, cancelF := context.WithTimeout(context.Background(), time.Minute)
+	t.Cleanup(cancelF)
+
+	return ctx, conn
+}
+
+func populateScenario(
+	t *testing.T,
+	ctx context.Context,
+	conn dbpkg.Conn,
+	specs []smtDomainSpec,
+) map[string]smtExpectedDomain {
+	t.Helper()
+
+	expected := make(map[string]smtExpectedDomain, len(specs))
+	for _, spec := range specs {
+		rand.Seed(spec.seed)
+
+		var certIDs []common.SHA256Output
+		var parentIDs []*common.SHA256Output
+		var names [][]string
+		var certs []ctx509.Certificate
+		var policies []common.PolicyDocument
+
+		if spec.kind != smtPolicyOnly {
+			certs, certIDs, parentIDs, names = random.BuildTestRandomCertHierarchy(t, spec.name)
+		}
+		if spec.kind != smtCertOnly {
+			policies = random.BuildTestRandomPolicyHierarchy(t, spec.name)
+		}
+
+		err := UpdateWithKeepExisting(
+			ctx,
+			conn,
+			names,
+			certIDs,
+			parentIDs,
+			certs,
+			util.ExtractExpirations(certs),
+			policies,
+		)
+		require.NoError(t, err)
+
+		expected[spec.name] = smtExpectedDomain{
+			name:      spec.name,
+			certIDs:   append([]common.SHA256Output(nil), certIDs...),
+			policyIDs: computeIDsOfPolicies(t, policies),
+		}
+	}
+
+	return expected
+}
+
+func runSMTPath(
+	t *testing.T,
+	ctx context.Context,
+	conn dbpkg.Conn,
+	path string,
+	bundleSize int,
+) common.SHA256Output {
+	t.Helper()
+
+	rootBytes, err := loadRoot(ctx, conn)
+	require.NoError(t, err)
+
+	smtTrie, err := trie.NewTrie(rootBytes, common.SHA256Hash, conn)
+	require.NoError(t, err)
+	smtTrie.CacheHeightLimit = 32
+
+	switch path {
+	case "domains":
+		domains, err := conn.RetrieveDirtyDomains(ctx)
+		require.NoError(t, err)
+		err = updateSMTfromDomains(ctx, conn, smtTrie, domains, bundleSize)
+		require.NoError(t, err)
+	case "dirty":
+		err = updateSMTfromDirty(ctx, conn, smtTrie, uint64(bundleSize))
+		require.NoError(t, err)
+	default:
+		require.FailNow(t, fmt.Sprintf("unknown SMT path %q", path))
+	}
+
+	require.NotNil(t, smtTrie.Root)
+
+	var root common.SHA256Output
+	copy(root[:], smtTrie.Root)
+	require.NoError(t, conn.SaveRoot(ctx, &root))
+	return root
+}
+
+func loadSavedRoot(t *testing.T, ctx context.Context, conn dbpkg.Conn) *common.SHA256Output {
+	t.Helper()
+	root, err := conn.LoadRoot(ctx)
+	require.NoError(t, err)
+	return root
+}
+
+func reorderDirtyDomains(t *testing.T, ctx context.Context, conn dbpkg.Conn, ordered []common.SHA256Output) {
+	t.Helper()
+	require.NoError(t, conn.CleanupDirty(ctx))
+	require.NoError(t, conn.InsertDomainsIntoDirty(ctx, ordered))
+}
+
+func assertProofsValid(
+	t *testing.T,
+	ctx context.Context,
+	conn dbpkg.Conn,
+	checks ...smtProofCheck,
+) {
+	t.Helper()
+	for _, check := range checks {
+		leaf := getLeafProof(t, ctx, conn, check.domain)
+		if check.present {
+			require.Equal(t, mapcommon.PoP, leaf.PoI.ProofType)
+		} else {
+			require.Equal(t, mapcommon.PoA, leaf.PoI.ProofType)
+		}
+	}
+}
+
+func getLeafProof(
+	t *testing.T,
+	ctx context.Context,
+	conn dbpkg.Conn,
+	domain string,
+) *mapcommon.MapServerResponse {
+	t.Helper()
+
+	res, err := responder.NewMapResponder(ctx, conn, responderTestKey(t))
+	require.NoError(t, err)
+
+	proofs, err := res.GetProof(ctx, domain)
+	require.NoError(t, err)
+	require.NotEmpty(t, proofs)
+
+	for _, proof := range proofs {
+		_, ok, err := prover.VerifyProofByDomain(proof)
+		require.NoError(t, err)
+		require.True(t, ok)
+	}
+
+	return proofs[len(proofs)-1]
+}
+
+func assertLeafEntryMatches(
+	t *testing.T,
+	ctx context.Context,
+	conn dbpkg.Conn,
+	expected smtExpectedDomain,
+) {
+	t.Helper()
+
+	leaf := getLeafProof(t, ctx, conn, expected.name)
+	require.Equal(t, mapcommon.PoP, leaf.PoI.ProofType)
+
+	wantCertBytes, wantCertID := expected.certBytes(t)
+	wantPolicyBytes, wantPolicyID := expected.policyBytes(t)
+
+	if len(expected.certIDs) == 0 {
+		require.Empty(t, leaf.DomainEntry.CertIDs)
+	} else {
+		require.Equal(t, wantCertBytes, leaf.DomainEntry.CertIDs)
+		require.Equal(t, wantCertID, leaf.DomainEntry.CertIDsID)
+	}
+
+	if len(expected.policyIDs) == 0 {
+		require.Empty(t, leaf.DomainEntry.PolicyIDs)
+	} else {
+		require.Equal(t, wantPolicyBytes, leaf.DomainEntry.PolicyIDs)
+		require.Equal(t, wantPolicyID, leaf.DomainEntry.PolicyIDsID)
+	}
+}
+
+func responderTestKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+
+	key, err := util.RSAKeyFromPEMFile(filepath.Join("..", "responder", "testdata", "server_key.pem"))
+	require.NoError(t, err)
+	return key
+}

--- a/pkg/mapserver/updater/updater.go
+++ b/pkg/mapserver/updater/updater.go
@@ -566,25 +566,10 @@ func UpdateSMT(ctx context.Context, conn db.Conn) error {
 		return nil
 	}
 
-	// deleteme re-enable updateSMTfromDirty instead of using updateSMTfromDomains.
-	// Commented out: testing if the in-db join-with-dirty table is faster.
-	// Get the dirty domains.
-	domains, err := conn.RetrieveDirtyDomains(ctx)
+	err = updateSMTfromDirty(ctx, conn, smtTrie, 1_000_000)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("smt [%s]: dirty domains loaded\n", time.Now().Format(time.Stamp))
-
-	err = updateSMTfromDomains(ctx, conn, smtTrie, domains, 1_000_000)
-	if err != nil {
-		return err
-	}
-
-	// // Updating SMT directly from dirty table.
-	// err = updateSMTfromDirty(ctx, conn, smtTrie, 1_000_000)
-	// if err != nil {
-	// 	return err
-	// }
 
 	fmt.Printf("\nsmt [%s]: SMT updated\n", time.Now().Format(time.Stamp))
 
@@ -733,9 +718,15 @@ func keyValuePairToSMTInput(keyValuePair []db.KeyValuePair) ([][]byte, [][]byte,
 	}
 	updateInput := make([]inputPair, 0, len(keyValuePair))
 	for _, pair := range keyValuePair {
+		value := pair.Value
+		if len(value) == 0 {
+			value = trie.DefaultLeaf
+		} else {
+			value = common.SHA256Hash(value) // Compute SHA256 of the payload.
+		}
 		updateInput = append(updateInput, inputPair{
 			Key:   pair.Key,
-			Value: common.SHA256Hash(pair.Value), // Compute SHA256 of the payload.
+			Value: value,
 		})
 	}
 

--- a/pkg/mapserver/updater/updater.go
+++ b/pkg/mapserver/updater/updater.go
@@ -483,37 +483,6 @@ func updateSMTfromDirty(
 	}
 }
 
-func updateSMTfromDomains(
-	ctx context.Context,
-	conn db.Conn,
-	smtTrie *trie.Trie,
-	domainIDs []common.SHA256Output,
-	max_bundle_size int,
-) error {
-
-	// We split the certificates into bundles.
-	bundleCount := len(domainIDs) / max_bundle_size
-	for i := 0; i <= bundleCount; i++ {
-		// Read those certificates:
-		s := i * max_bundle_size
-		e := min(s+max_bundle_size, len(domainIDs))
-		fmt.Printf("smt.updateSMTfromDomains [%s]: retrieving certs from DB\n"+
-			"\t\t[%8d,%8d) %3d/%3d\n", time.Now().Format(time.Stamp), s, e, i+1, bundleCount+1)
-		entries, err := conn.RetrieveDomainEntries(ctx, domainIDs[s:e])
-		if err != nil {
-			return err
-		}
-		fmt.Printf("smt.updateSMTfromDomains [%s]: got certs from DB\n", time.Now().Format(time.Stamp))
-
-		err = updateSMTfromKeyValues(ctx, smtTrie, entries)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func updateSMTfromKeyValues(
 	ctx context.Context,
 	smtTrie *trie.Trie,

--- a/pkg/mapserver/updater/updater.go
+++ b/pkg/mapserver/updater/updater.go
@@ -474,7 +474,7 @@ func updateSMTfromDirty(
 			time.Now().Format(time.Stamp), len(entries), bundleNum)
 
 		cursor = nextCursor
-		if err := updateSMTfromKeyValues(ctx, smtTrie, entries); err != nil {
+		if err := updateSMTFromDomainEntries(ctx, smtTrie, entries); err != nil {
 			return err
 		}
 		if done {
@@ -483,18 +483,20 @@ func updateSMTfromDirty(
 	}
 }
 
-func updateSMTfromKeyValues(
+// updateSMTFromDomainEntries updates and commits the SMT using domain-entry
+// records retrieved from the database.
+func updateSMTFromDomainEntries(
 	ctx context.Context,
 	smtTrie *trie.Trie,
-	entries []db.KeyValuePair,
+	entries []db.DomainEntryRecord,
 ) error {
 
 	// Adapt data type.
-	keys, values, err := keyValuePairToSMTInput(entries)
+	keys, values, err := domainEntriesToSMTInput(entries)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("\nsmt.updateSMTfromKeyValues [%s]: keys and values obtained\n", time.Now().Format(time.Stamp))
+	fmt.Printf("\nsmt.updateSMTFromDomainEntries [%s]: keys and values obtained\n", time.Now().Format(time.Stamp))
 
 	// Update the tree.
 	_, err = smtTrie.Update(ctx, keys, values)
@@ -502,7 +504,7 @@ func updateSMTfromKeyValues(
 	if err != nil {
 		return err
 	}
-	fmt.Printf("\nsmt.updateSMTfromKeyValues [%s]: in-memory tree updated\n", time.Now().Format(time.Stamp))
+	fmt.Printf("\nsmt.updateSMTFromDomainEntries [%s]: in-memory tree updated\n", time.Now().Format(time.Stamp))
 
 	// And update the tree in the DB.
 	err = smtTrie.Commit(ctx)
@@ -512,7 +514,7 @@ func updateSMTfromKeyValues(
 	}
 	// Remove existing entries to avoid OOM issues.
 	smtTrie.ResetLiveCache()
-	fmt.Printf("\nsmt.updateSMTfromKeyValues [%s]: tree committed to DB\n", time.Now().Format(time.Stamp))
+	fmt.Printf("\nsmt.updateSMTFromDomainEntries [%s]: tree committed to DB\n", time.Now().Format(time.Stamp))
 	return nil
 }
 
@@ -685,21 +687,23 @@ func runWhenFalse(mask []bool, fcn func(to, from int)) int {
 	return to
 }
 
-// keyValuePairToSMTInput converts DB results into SMT update input.
-// RetrieveDomainEntries already returns the final SMT leaf hash for non-empty values.
-func keyValuePairToSMTInput(keyValuePair []db.KeyValuePair) ([][]byte, [][]byte, error) {
+// domainEntriesToSMTInput converts domain-entry DB results into SMT update
+// input by hashing non-empty domain-entry payloads.
+func domainEntriesToSMTInput(entries []db.DomainEntryRecord) ([][]byte, [][]byte, error) {
 	type inputPair struct {
 		Key   [32]byte
 		Value []byte
 	}
-	updateInput := make([]inputPair, 0, len(keyValuePair))
-	for _, pair := range keyValuePair {
-		value := pair.Value
+	updateInput := make([]inputPair, 0, len(entries))
+	for _, pair := range entries {
+		value := pair.Payload
 		if len(value) == 0 {
 			value = trie.DefaultLeaf
+		} else {
+			value = common.SHA256Hash(value)
 		}
 		updateInput = append(updateInput, inputPair{
-			Key:   pair.Key,
+			Key:   pair.DomainID,
 			Value: value,
 		})
 	}

--- a/pkg/mapserver/updater/updater.go
+++ b/pkg/mapserver/updater/updater.go
@@ -451,29 +451,36 @@ func updateSMTfromDirty(
 	smtTrie *trie.Trie,
 	max_bundle_size uint64,
 ) error {
+	if max_bundle_size == 0 {
+		return fmt.Errorf("max bundle size must be > 0")
+	}
 
-	// We split the certificates into bundles.
-	count, err := conn.DirtyCount(ctx)
-	if err != nil {
-		return fmt.Errorf("obtaining dirty domains count: %w", err)
-	}
-	bundleCount := count / max_bundle_size
-	for i := uint64(0); i <= bundleCount; i++ {
-		// Read those certificates:
-		s := i * max_bundle_size
-		e := min(s+max_bundle_size, count)
-		fmt.Printf("smt.updateSMTfromDirty [%s]: retrieving certs from DB\n"+
-			"\t\t[%8d,%8d) %3d/%3d\n", time.Now().Format(time.Stamp), s, e, i+1, bundleCount+1)
-		entries, err := conn.RetrieveDomainEntriesDirtyOnes(ctx, s, e)
+	var cursor *db.DirtyDomainEntriesCursor
+	for bundleNum := 1; ; bundleNum++ {
+		fmt.Printf("smt.updateSMTfromDirty [%s]: retrieving bundle %d from DB (max %d domains)\n",
+			time.Now().Format(time.Stamp), bundleNum, max_bundle_size)
+		entries, nextCursor, done, err := conn.RetrieveDomainEntriesDirtyBundle(
+			ctx,
+			cursor,
+			max_bundle_size,
+		)
 		if err != nil {
 			return err
 		}
-		err = updateSMTfromKeyValues(ctx, smtTrie, entries)
-		if err != nil {
+		if len(entries) == 0 {
+			return nil
+		}
+		fmt.Printf("smt.updateSMTfromDirty [%s]: got %d entries for bundle %d\n",
+			time.Now().Format(time.Stamp), len(entries), bundleNum)
+
+		cursor = nextCursor
+		if err := updateSMTfromKeyValues(ctx, smtTrie, entries); err != nil {
 			return err
 		}
+		if done {
+			return nil
+		}
 	}
-	return nil
 }
 
 func updateSMTfromDomains(

--- a/pkg/mapserver/updater/updater.go
+++ b/pkg/mapserver/updater/updater.go
@@ -541,6 +541,8 @@ func updateSMTfromKeyValues(
 	if err != nil {
 		return err
 	}
+	// Remove existing entries to avoid OOM issues.
+	smtTrie.ResetLiveCache()
 	fmt.Printf("\nsmt.updateSMTfromKeyValues [%s]: tree committed to DB\n", time.Now().Format(time.Stamp))
 	return nil
 }
@@ -714,10 +716,8 @@ func runWhenFalse(mask []bool, fcn func(to, from int)) int {
 	return to
 }
 
-// keyValuePairToSMTInput: key value pair -> SMT update input
-// deleteme TODO this function takes the payload and computes the hash of it. The hash is already
-// stored in the DB with the new design: change both the function RetrieveDomainEntries and
-// remove the hashing from this keyValuePairToSMTInput function.
+// keyValuePairToSMTInput converts DB results into SMT update input.
+// RetrieveDomainEntries already returns the final SMT leaf hash for non-empty values.
 func keyValuePairToSMTInput(keyValuePair []db.KeyValuePair) ([][]byte, [][]byte, error) {
 	type inputPair struct {
 		Key   [32]byte
@@ -728,8 +728,6 @@ func keyValuePairToSMTInput(keyValuePair []db.KeyValuePair) ([][]byte, [][]byte,
 		value := pair.Value
 		if len(value) == 0 {
 			value = trie.DefaultLeaf
-		} else {
-			value = common.SHA256Hash(value) // Compute SHA256 of the payload.
 		}
 		updateInput = append(updateInput, inputPair{
 			Key:   pair.Key,

--- a/pkg/tests/noopdb/db.go
+++ b/pkg/tests/noopdb/db.go
@@ -53,6 +53,14 @@ func (*Conn) RetrieveDomainEntriesDirtyOnes(context.Context, uint64, uint64) ([]
 	return nil, nil
 }
 
+func (*Conn) RetrieveDomainEntriesDirtyBundle(
+	context.Context,
+	*db.DirtyDomainEntriesCursor,
+	uint64,
+) ([]db.KeyValuePair, *db.DirtyDomainEntriesCursor, bool, error) {
+	return nil, nil, true, nil
+}
+
 func (*Conn) LoadRoot(context.Context) (*common.SHA256Output, error) {
 	return nil, nil
 }

--- a/pkg/tests/noopdb/db.go
+++ b/pkg/tests/noopdb/db.go
@@ -45,11 +45,11 @@ func (*Conn) UpdateDomains(context.Context, []common.SHA256Output, []string) err
 	return nil
 }
 
-func (*Conn) RetrieveDomainEntries(context.Context, []common.SHA256Output) ([]db.KeyValuePair, error) {
+func (*Conn) RetrieveDomainEntries(context.Context, []common.SHA256Output) ([]db.DomainEntryRecord, error) {
 	return nil, nil
 }
 
-func (*Conn) RetrieveDomainEntriesDirtyOnes(context.Context, uint64, uint64) ([]db.KeyValuePair, error) {
+func (*Conn) RetrieveDomainEntriesDirtyOnes(context.Context, uint64, uint64) ([]db.DomainEntryRecord, error) {
 	return nil, nil
 }
 
@@ -57,7 +57,7 @@ func (*Conn) RetrieveDomainEntriesDirtyBundle(
 	context.Context,
 	*db.DirtyDomainEntriesCursor,
 	uint64,
-) ([]db.KeyValuePair, *db.DirtyDomainEntriesCursor, bool, error) {
+) ([]db.DomainEntryRecord, *db.DirtyDomainEntriesCursor, bool, error) {
 	return nil, nil, true, nil
 }
 
@@ -71,7 +71,7 @@ func (*Conn) SaveRoot(context.Context, *common.SHA256Output) error {
 func (*Conn) RetrieveTreeNode(context.Context, common.SHA256Output) ([]byte, error) {
 	return nil, nil
 }
-func (*Conn) UpdateTreeNodes(context.Context, []*db.KeyValuePair) (int, error) {
+func (*Conn) UpdateTreeNodes(context.Context, []*db.TreeNodeRecord) (int, error) {
 	return 0, nil
 }
 func (*Conn) DeleteTreeNodes(context.Context, []common.SHA256Output) (int, error) {

--- a/pkg/tests/testdb/testdb_test.go
+++ b/pkg/tests/testdb/testdb_test.go
@@ -11,7 +11,7 @@ import (
 
 // TestConfigureTestDB checks that the ConfigureTestDB function works properly.
 func TestConfigureTestDB(t *testing.T) {
-	ctx, cancelF := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancelF := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelF()
 	tests.TestOrTimeout(t, tests.WithContext(ctx), func(t tests.T) {
 		conf, removeF := ConfigureTestDB(t)
@@ -21,7 +21,7 @@ func TestConfigureTestDB(t *testing.T) {
 }
 
 func TestCreateTestDB(t *testing.T) {
-	ctx, cancelF := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancelF := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelF()
 
 	tests.TestOrTimeout(t, tests.WithContext(ctx), func(t tests.T) {


### PR DESCRIPTION
The process of updating the SMT has been consuming huge amounts of RAM.
This PR reduces the memory consumption,
as well as limits the number of concurrent node update workers, instead of blindly spawning a new goroutine per child node.
Additionally, we now split `KeyValuePair` uses into `TreeNodeRecord` and `DomainEntryRecord`,
to represent semantics for the trie and domain entries in the DB tree table, respectively.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/fpki/99)
<!-- Reviewable:end -->
