### PR TITLE
Fix issues after updating Go version

### DIFF
--- a/pkg/common/crypto/crypto_test.go
+++ b/pkg/common/crypto/crypto_test.go
@@ -4,7 +4,6 @@ import (
 	cryptolib "crypto"
 	"crypto/rsa"
 	"io/ioutil"
-	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,7 +18,7 @@ import (
 var update = tests.UpdateGoldenFiles()
 
 func TestUpdateGoldenFiles(t *testing.T) {
-	rand.Seed(0)
+	random.Seed(0)
 	if !*update {
 		t.Skip("Not updating golden files: flag not set")
 	}
@@ -90,7 +89,7 @@ func TestUpdateGoldenFiles(t *testing.T) {
 }
 
 func TestComputeHashAsOwner(t *testing.T) {
-	rand.Seed(1)
+	random.Seed(1)
 
 	// Get random policy certificate and check it contains SPCTs, owner, and issuer fields.
 	pc := random.RandomPolicyCertificate(t)
@@ -115,7 +114,7 @@ func TestComputeHashAsOwner(t *testing.T) {
 }
 
 func TestSignAsOwner(t *testing.T) {
-	rand.Seed(11)
+	random.Seed(11)
 
 	// Load owner policy cert and key.
 	ownerCert, err := util.PolicyCertificateFromFile("../../../tests/testdata/owner_cert.json")
@@ -172,7 +171,7 @@ func TestSignAsOwner(t *testing.T) {
 }
 
 func TestSignPolicyCertificateAsIssuer(t *testing.T) {
-	rand.Seed(12)
+	random.Seed(12)
 
 	// Load issuer policy cert and key.
 	issuerCert, err := util.PolicyCertificateFromFile("../../../tests/testdata/issuer_cert.json")
@@ -230,7 +229,7 @@ func TestSignPolicyCertificateAsIssuer(t *testing.T) {
 }
 
 func TestSignRequestAsIssuer(t *testing.T) {
-	rand.Seed(13)
+	random.Seed(13)
 
 	// Load issuer policy cert and key.
 	issuerCert, err := util.PolicyCertificateFromFile("../../../tests/testdata/issuer_cert.json")

--- a/pkg/db/mysql/mysql_test.go
+++ b/pkg/db/mysql/mysql_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -70,7 +69,7 @@ func TestPartitionByIdMSB(t *testing.T) {
 // TestUpdateCerts checks that the UpdateCerts function in DB works as expected.
 func TestUpdateCerts(t *testing.T) {
 	// Because we are using "random" bytes deterministically here, set a fixed seed.
-	rand.Seed(111)
+	random.Seed(111)
 
 	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()
@@ -108,7 +107,7 @@ func TestUpdateCerts(t *testing.T) {
 // certificates with the same ID (namely, the c0 and c1 ones).
 func TestUpdateCertsNonUnique(t *testing.T) {
 	// Because we are using "random" bytes deterministically here, set a fixed seed.
-	rand.Seed(111)
+	random.Seed(111)
 
 	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()
@@ -159,7 +158,7 @@ func TestUpdateCertsNonUnique(t *testing.T) {
 
 func TestCoalesceForDirtyDomains(t *testing.T) {
 	// Because we are using "random" bytes deterministically here, set a fixed seed.
-	rand.Seed(1)
+	random.Seed(1)
 
 	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()
@@ -233,7 +232,7 @@ func TestCoalesceForDirtyDomains(t *testing.T) {
 // when a domain has both certificates and policies.
 func TestCoalesceForDirtyDomains_MixedCertsAndPolicies(t *testing.T) {
 	// Because we are using "random" bytes deterministically here, set a fixed seed.
-	rand.Seed(1)
+	random.Seed(1)
 
 	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()
@@ -319,7 +318,7 @@ func TestCallCalcDirtyDomainsReturnsProcessedRows(t *testing.T) {
 // any certs or policies disappear from both domain_payloads and domains.
 func TestCoalesceForDirtyDomains_RemovesStaleDomainState(t *testing.T) {
 	// Because we are using "random" bytes deterministically here, set a fixed seed.
-	rand.Seed(1)
+	random.Seed(1)
 
 	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()
@@ -399,7 +398,7 @@ func TestCoalesceForDirtyDomains_RemovesStaleDomainState(t *testing.T) {
 }
 
 func TestCoalesceForDirtyDomains_MarksRowsCoalesced(t *testing.T) {
-	rand.Seed(1)
+	random.Seed(1)
 
 	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()
@@ -433,7 +432,7 @@ func TestCoalesceForDirtyDomains_MarksRowsCoalesced(t *testing.T) {
 }
 
 func TestInsertDomainsIntoDirty_ResetsCoalescedFlag(t *testing.T) {
-	rand.Seed(1)
+	random.Seed(1)
 
 	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()
@@ -613,7 +612,7 @@ func TestLastCTlogServerState(t *testing.T) {
 }
 
 func TestPruneCerts(t *testing.T) {
-	rand.Seed(322)
+	random.Seed(322)
 
 	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()
@@ -752,10 +751,8 @@ func TestRetrieveDomainEntries(t *testing.T) {
 
 	kvElementsMatch(t, expected, parallel, "len(expected)=%d,len(got)=%d",
 		len(expected), len(parallel))
-	require.NotSame(t, expected, parallel)
 	kvElementsMatch(t, expected, joined, "len(expected)=%d,len(got)=%d",
 		len(expected), len(parallel))
-	require.NotSame(t, expected, joined)
 }
 
 // TestRetrieveDomainEntriesDirtyBundle checks that bundle-based dirty-domain

--- a/pkg/logverifier/logverifier_test.go
+++ b/pkg/logverifier/logverifier_test.go
@@ -1,7 +1,6 @@
 package logverifier
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/google/trillian"
@@ -38,7 +37,7 @@ func TestVerifySPT(t *testing.T) {
 
 func TestVerifyInclusionByHash(t *testing.T) {
 	// Because we are using "random" bytes deterministically here, set a fixed seed.
-	rand.Seed(1)
+	random.Seed(1)
 
 	// Create a mock proof.
 	proof := &trillian.Proof{

--- a/pkg/mapserver/mapserver_test.go
+++ b/pkg/mapserver/mapserver_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"sync"
 	"testing"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/netsec-ethz/fpki/pkg/mapserver"
 	"github.com/netsec-ethz/fpki/pkg/mapserver/config"
+	testrand "github.com/netsec-ethz/fpki/pkg/tests/random"
 	"github.com/netsec-ethz/fpki/pkg/tests/testdb"
 	tup "github.com/netsec-ethz/fpki/pkg/tests/updater"
 	"github.com/netsec-ethz/fpki/pkg/util"
@@ -22,7 +22,7 @@ import (
 
 func TestServer(t *testing.T) {
 	// Because we are using "random" bytes deterministically here, set a fixed seed.
-	rand.Seed(1)
+	testrand.Seed(1)
 
 	ctx, cancelF := context.WithTimeout(context.Background(), time.Minute)
 	defer cancelF()
@@ -92,13 +92,18 @@ func TestServer(t *testing.T) {
 
 	wgClients := sync.WaitGroup{}
 	wgClients.Add(N)
+	selectedDomains := make([]string, N)
+	for i := range selectedDomains {
+		selectedDomains[i] = domains[testrand.RandomInt(t, 0, len(domains)-1)]
+	}
 	t.Log("Starting clients")
 	for i := 0; i < N; i++ {
+		domain := selectedDomains[i]
 		go func() {
 			defer wgClients.Done()
 
 			resp, err := client.Get(fmt.Sprintf("https://localhost:%d/getproof?domain=%s",
-				server.HttpAPIPort, domains[rand.Intn(len(domains))]))
+				server.HttpAPIPort, domain))
 			require.NoError(t, err)
 			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
@@ -125,7 +130,7 @@ func BenchmarkAPIGetProof1K(b *testing.B) {
 
 func benchmarkAPIGetProof(b *testing.B, numDifferentDomains int) {
 	// Because we are using "random" bytes deterministically here, set a fixed seed.
-	rand.Seed(1)
+	testrand.Seed(1)
 
 	ctx, cancelF := context.WithTimeout(context.Background(), time.Minute)
 	defer cancelF()
@@ -177,17 +182,22 @@ func benchmarkAPIGetProof(b *testing.B, numDifferentDomains int) {
 	client := &http.Client{
 		Transport: tr,
 	}
+	selectedDomains := make([]string, b.N)
+	for i := range selectedDomains {
+		selectedDomains[i] = domains[testrand.RandomInt(b, 0, len(domains)-1)]
+	}
 
 	// Benchmark with concurrent clients.
 	wg := sync.WaitGroup{}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		wg.Add(1)
+		domain := selectedDomains[i]
 		go func() {
 			defer wg.Done()
 
 			resp, err := client.Get(fmt.Sprintf("https://localhost:%d/getproof?domain=%s",
-				server.HttpAPIPort, domains[rand.Intn(len(domains))]))
+				server.HttpAPIPort, domain))
 			b.StopTimer()
 			require.NoError(b, err)
 			body, err := io.ReadAll(resp.Body)
@@ -206,7 +216,7 @@ func BenchmarkAPIGetPayloads1K(b *testing.B) {
 
 func benchmarkAPIGetPayloads(b *testing.B, numDifferentDomains int) {
 	// Because we are using "random" bytes deterministically here, set a fixed seed.
-	rand.Seed(1)
+	testrand.Seed(1)
 
 	ctx, cancelF := context.WithTimeout(context.Background(), time.Minute)
 	defer cancelF()
@@ -257,18 +267,22 @@ func benchmarkAPIGetPayloads(b *testing.B, numDifferentDomains int) {
 	client := &http.Client{
 		Transport: tr,
 	}
+	selectedIDs := make([]string, b.N)
+	for i := range selectedIDs {
+		selectedIDs[i] = hex.EncodeToString(certIDs[testrand.RandomInt(b, 0, len(certIDs)-1)][:])
+	}
 
 	// Benchmark with concurrent clients.
 	wg := sync.WaitGroup{}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		wg.Add(1)
+		id := selectedIDs[i]
 		go func() {
 			defer wg.Done()
 
-			ID := hex.EncodeToString(certIDs[rand.Intn(len(certIDs))][:])
 			resp, err := client.Get(fmt.Sprintf("https://localhost:%d/getcertpayloads?ids=%s",
-				server.HttpAPIPort, ID))
+				server.HttpAPIPort, id))
 			b.StopTimer()
 			require.NoError(b, err)
 			body, err := io.ReadAll(resp.Body)

--- a/pkg/mapserver/responder/responder_test.go
+++ b/pkg/mapserver/responder/responder_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rsa"
 	"encoding/hex"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -14,6 +13,7 @@ import (
 	mapcommon "github.com/netsec-ethz/fpki/pkg/mapserver/common"
 	"github.com/netsec-ethz/fpki/pkg/mapserver/prover"
 	"github.com/netsec-ethz/fpki/pkg/tests"
+	"github.com/netsec-ethz/fpki/pkg/tests/random"
 	"github.com/netsec-ethz/fpki/pkg/tests/testdb"
 	tup "github.com/netsec-ethz/fpki/pkg/tests/updater"
 	"github.com/netsec-ethz/fpki/pkg/util"
@@ -62,7 +62,7 @@ func TestNewResponder(t *testing.T) {
 // creating a responder, and checking those domains.
 func TestProof(t *testing.T) {
 	// Because we are using "random" bytes deterministically here, set a fixed seed.
-	rand.Seed(1)
+	random.Seed(1)
 
 	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()

--- a/pkg/mapserver/trie/trie_test.go
+++ b/pkg/mapserver/trie/trie_test.go
@@ -7,13 +7,14 @@ package trie
 
 import (
 	"context"
-	"math/rand"
+	"io"
 	"runtime"
 	"sort"
 	"testing"
 	"time"
 
 	"github.com/netsec-ethz/fpki/pkg/common"
+	testrand "github.com/netsec-ethz/fpki/pkg/tests/random"
 	"github.com/netsec-ethz/fpki/pkg/tests/testdb"
 	"github.com/stretchr/testify/require"
 )
@@ -36,7 +37,7 @@ func TestTrieEmpty(t *testing.T) {
 
 // TestTrieUpdateAndGet: Update leaves and get leaves
 func TestTrieUpdateAndGet(t *testing.T) {
-	rand.Seed(1)
+	testrand.Seed(1)
 	ctx, cancelF := context.WithTimeout(context.Background(), time.Minute)
 	defer cancelF()
 
@@ -83,7 +84,7 @@ func TestTrieUpdateAndGet(t *testing.T) {
 
 // TestTrieAtomicUpdate: test AtomicUpdate()
 func TestTrieAtomicUpdate(t *testing.T) {
-	rand.Seed(1)
+	testrand.Seed(1)
 	ctx, cancelF := context.WithTimeout(context.Background(), time.Minute)
 	defer cancelF()
 
@@ -120,7 +121,7 @@ func TestTrieAtomicUpdate(t *testing.T) {
 
 // TestTriePublicUpdateAndGet: test Update() and verify the memory
 func TestTriePublicUpdateAndGet(t *testing.T) {
-	rand.Seed(1)
+	testrand.Seed(1)
 	ctx, cancelF := context.WithTimeout(context.Background(), time.Minute)
 	defer cancelF()
 
@@ -164,7 +165,7 @@ func TestTriePublicUpdateAndGet(t *testing.T) {
 
 // TestTrieUpdateAndDelete: test updating and deleting at the same time
 func TestTrieUpdateAndDelete(t *testing.T) {
-	rand.Seed(1)
+	testrand.Seed(1)
 	ctx, cancelF := context.WithTimeout(context.Background(), time.Minute)
 	defer cancelF()
 
@@ -210,7 +211,7 @@ func TestTrieUpdateAndDelete(t *testing.T) {
 // TestTrieUpdateParallelismIsBounded checks that large trie updates respect the
 // internal goroutine cap instead of recursively spawning unbounded workers.
 func TestTrieUpdateParallelismIsBounded(t *testing.T) {
-	rand.Seed(1)
+	testrand.Seed(1)
 	ctx, cancelF := context.WithTimeout(context.Background(), time.Minute)
 	defer cancelF()
 
@@ -236,7 +237,7 @@ func TestTrieUpdateParallelismIsBounded(t *testing.T) {
 
 // TestTrieMerkleProof: test if merkle proof is correct
 func TestTrieMerkleProof(t *testing.T) {
-	rand.Seed(1)
+	testrand.Seed(1)
 	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()
 
@@ -275,7 +276,7 @@ func TestTrieMerkleProof(t *testing.T) {
 
 // TestTrieMerkleProofCompressed: compressed proofs test
 func TestTrieMerkleProofCompressed(t *testing.T) {
-	rand.Seed(1)
+	testrand.Seed(1)
 	ctx, cancelF := context.WithTimeout(context.Background(), time.Minute)
 	defer cancelF()
 
@@ -311,7 +312,7 @@ func TestTrieMerkleProofCompressed(t *testing.T) {
 }
 
 func TestHeight0LeafShortcut(t *testing.T) {
-	rand.Seed(1)
+	testrand.Seed(1)
 	ctx, cancelF := context.WithTimeout(context.Background(), time.Minute)
 	defer cancelF()
 
@@ -376,7 +377,7 @@ func getRandomData(t require.TestingT, count int) [][]byte {
 	data := make([][]byte, count)
 	for i := 0; i < count; i++ {
 		key := make([]byte, common.SHA256Size)
-		_, err := rand.Read(key)
+		_, err := io.ReadFull(testrand.NewRandReader(), key)
 		require.NoError(t, err)
 		data[i] = key
 	}

--- a/pkg/mapserver/updater/smt_correctness_test.go
+++ b/pkg/mapserver/updater/smt_correctness_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rsa"
 	"encoding/hex"
 	"fmt"
-	"math/rand"
 	"path/filepath"
 	"testing"
 	"time"
@@ -395,7 +394,7 @@ func populateScenario(
 
 	expected := make(map[string]smtExpectedDomain, len(specs))
 	for _, spec := range specs {
-		rand.Seed(spec.seed)
+		random.Seed(spec.seed)
 
 		var certIDs []common.SHA256Output
 		var parentIDs []*common.SHA256Output

--- a/pkg/mapserver/updater/updater_test.go
+++ b/pkg/mapserver/updater/updater_test.go
@@ -3,7 +3,6 @@ package updater
 import (
 	"context"
 	"encoding/hex"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -23,7 +22,7 @@ import (
 func TestUpdateWithKeepExisting(t *testing.T) {
 	t0 := time.Now()
 	// Because we are using "random" bytes deterministically here, set a fixed seed.
-	rand.Seed(111)
+	random.Seed(111)
 
 	ctx, cancelF := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelF()

--- a/pkg/tests/random/random.go
+++ b/pkg/tests/random/random.go
@@ -17,7 +17,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var keyCreatingRandomCerts = RandomRSAPrivateKey(tests.NewTestObject("test_RSA_key"))
+const defaultSeed int64 = 1
+
+var (
+	randomSource           *rand.Rand
+	keyCreatingRandomCerts *rsa.PrivateKey
+)
+
+func init() {
+	Seed(defaultSeed)
+}
+
+// Seed resets this package's deterministic RNG state.
+func Seed(seed int64) {
+	randomSource = rand.New(rand.NewSource(seed))
+	keyCreatingRandomCerts = RandomRSAPrivateKey(tests.NewTestObject("test_RSA_key"))
+	// Restore the RNG as if it was never advanced by the RSA generation:
+	randomSource = rand.New(rand.NewSource(seed))
+}
 
 // randReader is a type implementing io.Reader which _fools_ `rsa.GenerateKey` to always generate
 // reproducible keys if the random source is deterministic (reproducible).
@@ -25,28 +42,33 @@ var keyCreatingRandomCerts = RandomRSAPrivateKey(tests.NewTestObject("test_RSA_k
 type randReader struct{}
 
 func (randReader) Read(p []byte) (int, error) {
-	if len(p) == 1 {
-		return 1, nil
-	}
-	return rand.Read(p)
+	return readFromSource(randomSource, p)
 }
 
-// NewRandReader returns an io.Reader that forces rsa.GenerateKeys to generate reproducible keys,
-// iff the random source is deterministic. Make a prior call to `rand.Seed()` to obtain
-// deterministic results, otherwise the random source will be pseudorandom but
-// probably not reproducible.
+func readFromSource(source *rand.Rand, p []byte) (int, error) {
+	if len(p) == 1 {
+		// XXX(juagargi) crypto/rsa may do an optional one-byte read via randutil.MaybeReadByte.
+		// Pretend that read succeeded without advancing our deterministic stream.
+		return 1, nil
+	}
+	return source.Read(p)
+}
+
+// NewRandReader returns an io.Reader that forces rsa.GenerateKeys to generate reproducible keys
+// using this package's RNG state. Make a prior call to `random.Seed()` to obtain deterministic
+// results.
 func NewRandReader() io.Reader {
 	return randReader{}
 }
 
 // RandomInt returns a random integer in the interval [from,to], both included.
 func RandomInt(t tests.T, from, to int) int {
-	return rand.Intn(to-from+1) + from
+	return randomSource.Intn(to-from+1) + from
 }
 
 func RandomBytesForTest(t tests.T, size int) []byte {
 	buff := make([]byte, size)
-	n, err := rand.Read(buff)
+	n, err := randomSource.Read(buff)
 	require.NoError(t, err)
 	require.Equal(t, size, n)
 	return buff
@@ -86,7 +108,7 @@ func RandomLeafNames(t tests.T, N int) []string {
 // RandomX509Cert creates a random x509 certificate, with correct ASN.1 DER representation.
 func RandomX509Cert(t tests.T, domain string) ctx509.Certificate {
 	template := ctx509.Certificate{
-		SerialNumber: big.NewInt(rand.Int63()),
+		SerialNumber: big.NewInt(randomSource.Int63()),
 		Subject: pkix.Name{
 			CommonName: domain,
 		},
@@ -299,12 +321,12 @@ func BuildTestRandomUniqueCertsTree(t tests.T, domainNames ...string) (
 
 func RandomTimeWithoutMonotonicBounded(minYear, maxYear int) time.Time {
 	return time.Date(
-		minYear+rand.Intn(maxYear-minYear+1),
-		time.Month(1+rand.Intn(12)), // 1-12
-		1+rand.Intn(31),             // 1-31
-		rand.Intn(24),               // 0-23
-		rand.Intn(60),               // 0-59
-		rand.Intn(60),               // 0-59
+		minYear+randomSource.Intn(maxYear-minYear+1),
+		time.Month(1+randomSource.Intn(12)), // 1-12
+		1+randomSource.Intn(31),             // 1-31
+		randomSource.Intn(24),               // 0-23
+		randomSource.Intn(60),               // 0-59
+		randomSource.Intn(60),               // 0-59
 		0,
 		time.UTC,
 	)
@@ -316,7 +338,7 @@ func RandomTimeWithoutMonotonic() time.Time {
 
 func RandomSignedPolicyCertificateTimestamp(t tests.T) *common.SignedPolicyCertificateTimestamp {
 	return common.NewSignedPolicyCertificateTimestamp(
-		rand.Intn(10),                // version
+		randomSource.Intn(10),        // version
 		RandomBytesForTest(t, 10),    // log id
 		RandomTimeWithoutMonotonic(), // timestamp
 		RandomBytesForTest(t, 32),    // signature
@@ -328,7 +350,7 @@ func RandomSignedPolicyCertificateRevocationTimestamp(
 ) *common.SignedPolicyCertificateRevocationTimestamp {
 
 	return common.NewSignedPolicyCertificateRevocationTimestamp(
-		rand.Intn(10),                // version
+		randomSource.Intn(10),        // version
 		RandomBytesForTest(t, 10),    // log id
 		RandomTimeWithoutMonotonic(), // timestamp
 		RandomBytesForTest(t, 32),    // signature
@@ -337,9 +359,9 @@ func RandomSignedPolicyCertificateRevocationTimestamp(
 
 func RandomPolCertSignRequest(t tests.T) *common.PolicyCertificateSigningRequest {
 	return common.NewPolicyCertificateSigningRequest(
-		rand.Intn(10),
-		rand.Intn(1000), // serial number
-		"domain",        // domain
+		randomSource.Intn(10),
+		randomSource.Intn(1000), // serial number
+		"domain",                // domain
 		RandomTimeWithoutMonotonic(),
 		RandomTimeWithoutMonotonic(),
 		true,                      // can issue
@@ -356,8 +378,8 @@ func RandomPolCertSignRequest(t tests.T) *common.PolicyCertificateSigningRequest
 
 func RandomPolicyCertificate(t tests.T) *common.PolicyCertificate {
 	return common.NewPolicyCertificate(
-		rand.Intn(10),
-		rand.Intn(1000), // serial number
+		randomSource.Intn(10),
+		randomSource.Intn(1000), // serial number
 		"fpki.com",
 		RandomTimeWithoutMonotonic(),
 		RandomTimeWithoutMonotonic(),
@@ -387,8 +409,8 @@ func RandomPolicyCertificateRevocationSigningRequest(t tests.T) *common.PolicyCe
 
 func RandomPolicyCertificateRevocation(t tests.T) *common.PolicyCertificateRevocation {
 	return common.NewPolicyCertificateRevocation(
-		rand.Intn(10),                // version
-		rand.Intn(1000),              // serial number
+		randomSource.Intn(10),        // version
+		randomSource.Intn(1000),      // serial number
 		RandomTimeWithoutMonotonic(), // timestamp
 		RandomBytesForTest(t, 32),    // owner signature
 		RandomBytesForTest(t, 32),    // owner hash
@@ -401,7 +423,9 @@ func RandomPolicyCertificateRevocation(t tests.T) *common.PolicyCertificateRevoc
 	)
 }
 
-// RandomRSAPrivateKey generates a NON-cryptographically secure RSA private key.
+// RandomRSAPrivateKey generates a NON-cryptographically secure RSA private key,
+// using the local-kept RNG initialized with a deterministic seed,
+// thus creating a reproducible series of private keys.
 func RandomRSAPrivateKey(t tests.T) *rsa.PrivateKey {
 	privateKeyPair, err := rsa.GenerateKey(NewRandReader(), 2048)
 	require.NoError(t, err)

--- a/pkg/tests/random/random_test.go
+++ b/pkg/tests/random/random_test.go
@@ -1,7 +1,6 @@
 package random_test
 
 import (
-	"math/rand"
 	"testing"
 
 	ctx509 "github.com/google/certificate-transparency-go/x509"
@@ -53,12 +52,12 @@ func TestRandomInt(t *testing.T) {
 }
 
 func TestRandomPolicyCertificate(t *testing.T) {
-	rand.Seed(0)
+	random.Seed(0)
 	pc1 := random.RandomPolicyCertificate(t)
 	pc2 := random.RandomPolicyCertificate(t)
 	require.NotEqual(t, pc1, pc2)
 
-	rand.Seed(0)
+	random.Seed(0)
 	gotPc1 := random.RandomPolicyCertificate(t)
 	gotPc2 := random.RandomPolicyCertificate(t)
 	require.Equal(t, pc1, gotPc1)
@@ -66,12 +65,12 @@ func TestRandomPolicyCertificate(t *testing.T) {
 }
 
 func TestRandomRSAPrivateKey(t *testing.T) {
-	rand.Seed(0)
+	random.Seed(0)
 	k1 := random.RandomRSAPrivateKey(t)
 	k2 := random.RandomRSAPrivateKey(t)
 	require.NotEqual(t, k1, k2)
 
-	rand.Seed(0)
+	random.Seed(0)
 	gotK1 := random.RandomRSAPrivateKey(t)
 	gotK2 := random.RandomRSAPrivateKey(t)
 	require.Equal(t, k1, gotK1)


### PR DESCRIPTION
Several issues have appeared after updating from 1.24 to 1.25.
- rand.Seed is a no-op now.
- Some changes in testify. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/fpki/109)
<!-- Reviewable:end -->
