### PR TITLE
ingest: record last index in db

### DIFF
--- a/cmd/ingest/cmdflags/flags.go
+++ b/cmd/ingest/cmdflags/flags.go
@@ -61,7 +61,8 @@ func _configureFlags() {
 		"\"\": full work. I.e. ingest files, coalesce, and update SMT.\n"+
 		"\"onlyingest\": do not coalesce or update SMT after ingesting files.\n"+
 		"\"skipingest\": only coalesce payloads of domains in the dirty table and update SMT.\n"+
-		"\"onlysmtupdate\": only update the SMT.\n")
+		"\"onlysmtupdate\": only update the SMT.\n"+
+		"\"updatectindex\": update ctlog_server_last_status from completed journal ranges.\n")
 	FileBatch = flag.Int("filebatch", 0, "process files in batches of this size. If zero, then "+
 		"all files are processed in one batch")
 	JournalFile = flag.String("journal", DefJournalFile,

--- a/cmd/ingest/cmdflags/flags.go
+++ b/cmd/ingest/cmdflags/flags.go
@@ -62,7 +62,7 @@ func _configureFlags() {
 		"\"onlyingest\": do not coalesce or update SMT after ingesting files.\n"+
 		"\"skipingest\": only coalesce payloads of domains in the dirty table and update SMT.\n"+
 		"\"onlysmtupdate\": only update the SMT.\n"+
-		"\"updatectindex\": update ctlog_server_last_status from completed journal ranges.\n")
+		"\"recordctsize\": update ctlog_server_last_status from completed journal ranges.\n")
 	FileBatch = flag.Int("filebatch", 0, "process files in batches of this size. If zero, then "+
 		"all files are processed in one batch")
 	JournalFile = flag.String("journal", DefJournalFile,

--- a/cmd/ingest/journal/journal.go
+++ b/cmd/ingest/journal/journal.go
@@ -49,15 +49,15 @@ type JobConfiguration struct {
 // UpdatedSMT records the stronger fact that the SMT update phase finished for
 // the same completed-index snapshot.
 type Job struct {
-	Cwd              string           `json:"Cwd"`
-	Cmd              []string         `json:"Cmd"`
-	JobConfiguration JobConfiguration `json:"JobConfiguration"`
-	StartTime        string           `json:"StartTime"`
-	EndTime          string           `json:"EndTime"`
-	Coalesced        bool             `json:"Coalesced"`
-	UpdatedSMT       bool             `json:"UpdatedSMT"`
-	UpdatedCTIndex   int64            `json:"UpdatedCTIndex"`
-	CompletedIndices CompletedIndices `json:"CompletedIndices"`
+	Cwd               string           `json:"Cwd"`
+	Cmd               []string         `json:"Cmd"`
+	JobConfiguration  JobConfiguration `json:"JobConfiguration"`
+	StartTime         string           `json:"StartTime"`
+	EndTime           string           `json:"EndTime"`
+	Coalesced         bool             `json:"Coalesced"`
+	UpdatedSMT        bool             `json:"UpdatedSMT"`
+	RecordedCTLogSize int64            `json:"RecordedCTLogSize"`
+	CompletedIndices  CompletedIndices `json:"CompletedIndices"`
 }
 
 // CompletedIndices groups completed certificate-index intervals by the
@@ -165,21 +165,21 @@ func (j *Journal) CommitProgress(files []string, coalesced bool, updatedSMT bool
 	return j.writeLocked()
 }
 
-// CommitCTIndex records the latest CT index size written to the DB for the
+// CommitCTLogSize records the latest CT log size written to the DB for the
 // current completed-index snapshot.
-func (j *Journal) CommitCTIndex(size int64) error {
+func (j *Journal) CommitCTLogSize(size int64) error {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
 	if j.closed {
-		return fmt.Errorf("cannot commit CT index to closed journal")
+		return fmt.Errorf("cannot commit CT log size to closed journal")
 	}
 
 	job, err := j.currentJob()
 	if err != nil {
 		return err
 	}
-	job.UpdatedCTIndex = size
+	job.RecordedCTLogSize = size
 	return j.writeLocked()
 }
 
@@ -277,14 +277,14 @@ func (j *Journal) appendJob(cfg JobConfiguration) error {
 	}
 
 	j.Jobs = append(j.Jobs, Job{
-		Cwd:              cwd,
-		Cmd:              slices.Clone(os.Args),
-		JobConfiguration: cfg,
-		StartTime:        time.Now().UTC().Format(time.RFC3339),
-		Coalesced:        j.latestCoalesced(),
-		UpdatedSMT:       j.latestUpdatedSMT(),
-		UpdatedCTIndex:   j.latestUpdatedCTIndex(),
-		CompletedIndices: cloneCompletedIndices(j.latestCompletedIndices()),
+		Cwd:               cwd,
+		Cmd:               slices.Clone(os.Args),
+		JobConfiguration:  cfg,
+		StartTime:         time.Now().UTC().Format(time.RFC3339),
+		Coalesced:         j.latestCoalesced(),
+		UpdatedSMT:        j.latestUpdatedSMT(),
+		RecordedCTLogSize: j.latestRecordedCTLogSize(),
+		CompletedIndices:  cloneCompletedIndices(j.latestCompletedIndices()),
 	})
 
 	return nil
@@ -439,11 +439,11 @@ func (j *Journal) latestUpdatedSMT() bool {
 	return j.Jobs[len(j.Jobs)-1].UpdatedSMT
 }
 
-func (j *Journal) latestUpdatedCTIndex() int64 {
+func (j *Journal) latestRecordedCTLogSize() int64 {
 	if len(j.Jobs) == 0 {
 		return -1
 	}
-	return j.Jobs[len(j.Jobs)-1].UpdatedCTIndex
+	return j.Jobs[len(j.Jobs)-1].RecordedCTLogSize
 }
 
 func (j *Journal) currentJob() (*Job, error) {

--- a/cmd/ingest/journal/journal.go
+++ b/cmd/ingest/journal/journal.go
@@ -31,11 +31,11 @@ type Journal struct {
 // JobConfiguration captures the ingest-mode settings that affect how one run
 // should execute and how its persisted state should be interpreted later.
 type JobConfiguration struct {
-	IngestFiles   bool
-	Coalesce      bool
-	UpdateSMT     bool
-	UpdateCTIndex bool
-	FileBatch     int
+	IngestFiles  bool
+	Coalesce     bool
+	UpdateSMT    bool
+	RecordCTSize bool
+	FileBatch    int
 	// IncludePlainCSVs opts the run into also listing uncompressed `.csv`
 	// bundles. When false, ingest only discovers `.gz` inputs.
 	IncludePlainCSVs bool
@@ -126,8 +126,8 @@ func NewJobConfiguration(strategy string, fileBatch int, includePlainCSVs bool) 
 		fallthrough
 	case "onlysmtupdate":
 		jc.UpdateSMT = true
-	case "updatectindex":
-		jc.UpdateCTIndex = true
+	case "recordctsize":
+		jc.RecordCTSize = true
 	default:
 		return JobConfiguration{}, fmt.Errorf("strategy value not understood by journal: %s", strategy)
 	}

--- a/cmd/ingest/journal/journal.go
+++ b/cmd/ingest/journal/journal.go
@@ -31,10 +31,11 @@ type Journal struct {
 // JobConfiguration captures the ingest-mode settings that affect how one run
 // should execute and how its persisted state should be interpreted later.
 type JobConfiguration struct {
-	IngestFiles bool
-	Coalesce    bool
-	UpdateSMT   bool
-	FileBatch   int
+	IngestFiles   bool
+	Coalesce      bool
+	UpdateSMT     bool
+	UpdateCTIndex bool
+	FileBatch     int
 	// IncludePlainCSVs opts the run into also listing uncompressed `.csv`
 	// bundles. When false, ingest only discovers `.gz` inputs.
 	IncludePlainCSVs bool
@@ -124,6 +125,8 @@ func NewJobConfiguration(strategy string, fileBatch int, includePlainCSVs bool) 
 		fallthrough
 	case "onlysmtupdate":
 		jc.UpdateSMT = true
+	case "updatectindex":
+		jc.UpdateCTIndex = true
 	default:
 		return JobConfiguration{}, fmt.Errorf("strategy value not understood by journal: %s", strategy)
 	}

--- a/cmd/ingest/journal/journal.go
+++ b/cmd/ingest/journal/journal.go
@@ -441,7 +441,7 @@ func (j *Journal) latestUpdatedSMT() bool {
 
 func (j *Journal) latestRecordedCTLogSize() int64 {
 	if len(j.Jobs) == 0 {
-		return -1
+		return 0
 	}
 	return j.Jobs[len(j.Jobs)-1].RecordedCTLogSize
 }

--- a/cmd/ingest/journal/journal.go
+++ b/cmd/ingest/journal/journal.go
@@ -56,6 +56,7 @@ type Job struct {
 	EndTime          string           `json:"EndTime"`
 	Coalesced        bool             `json:"Coalesced"`
 	UpdatedSMT       bool             `json:"UpdatedSMT"`
+	UpdatedCTIndex   int64            `json:"UpdatedCTIndex"`
 	CompletedIndices CompletedIndices `json:"CompletedIndices"`
 }
 
@@ -164,6 +165,24 @@ func (j *Journal) CommitProgress(files []string, coalesced bool, updatedSMT bool
 	return j.writeLocked()
 }
 
+// CommitCTIndex records the latest CT index size written to the DB for the
+// current completed-index snapshot.
+func (j *Journal) CommitCTIndex(size int64) error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	if j.closed {
+		return fmt.Errorf("cannot commit CT index to closed journal")
+	}
+
+	job, err := j.currentJob()
+	if err != nil {
+		return err
+	}
+	job.UpdatedCTIndex = size
+	return j.writeLocked()
+}
+
 // PendingFiles returns LiveDirectoryListing - CompletedIndices for the current
 // job. CompletedIndices is expected to already contain normalized ingest-dir
 // and interval coverage, so live files are normalized on the fly before
@@ -262,6 +281,9 @@ func (j *Journal) appendJob(cfg JobConfiguration) error {
 		Cmd:              slices.Clone(os.Args),
 		JobConfiguration: cfg,
 		StartTime:        time.Now().UTC().Format(time.RFC3339),
+		Coalesced:        j.latestCoalesced(),
+		UpdatedSMT:       j.latestUpdatedSMT(),
+		UpdatedCTIndex:   j.latestUpdatedCTIndex(),
 		CompletedIndices: cloneCompletedIndices(j.latestCompletedIndices()),
 	})
 
@@ -401,6 +423,27 @@ func (j *Journal) latestCompletedIndices() CompletedIndices {
 		return CompletedIndices{}
 	}
 	return j.Jobs[len(j.Jobs)-1].CompletedIndices
+}
+
+func (j *Journal) latestCoalesced() bool {
+	if len(j.Jobs) == 0 {
+		return false
+	}
+	return j.Jobs[len(j.Jobs)-1].Coalesced
+}
+
+func (j *Journal) latestUpdatedSMT() bool {
+	if len(j.Jobs) == 0 {
+		return false
+	}
+	return j.Jobs[len(j.Jobs)-1].UpdatedSMT
+}
+
+func (j *Journal) latestUpdatedCTIndex() int64 {
+	if len(j.Jobs) == 0 {
+		return -1
+	}
+	return j.Jobs[len(j.Jobs)-1].UpdatedCTIndex
 }
 
 func (j *Journal) currentJob() (*Job, error) {

--- a/cmd/ingest/journal/journal_test.go
+++ b/cmd/ingest/journal/journal_test.go
@@ -68,6 +68,7 @@ func TestNewJournal(t *testing.T) {
 	require.NotEmpty(t, latestJob(t, j).EndTime)
 	require.False(t, latestJob(t, j).Coalesced)
 	require.False(t, latestJob(t, j).UpdatedSMT)
+	require.Equal(t, int64(-1), latestJob(t, j).UpdatedCTIndex)
 	requireJSONDoesNotContainFiles(t, journalFile)
 
 	j, err = NewJournal(journalFile, testJobConfig(t, false), "")
@@ -147,6 +148,49 @@ func TestCommitProgressPhaseFlags(t *testing.T) {
 			require.Equal(t, tc.wantUpdatedSMT, job.UpdatedSMT)
 		})
 	}
+}
+
+// TestJournalCarriesForwardState verifies that reopening the journal preserves
+// the previous snapshot metadata when the completed indices are unchanged, and
+// that extending the snapshot preserves the last CT-index update while
+// invalidating coalesce and SMT state until those phases run again.
+func TestJournalCarriesForwardState(t *testing.T) {
+	journalFile := filepath.Join(t.TempDir(), "journal.json")
+
+	// Seed a journal snapshot that has completed work plus all derived follow-up
+	// metadata already recorded.
+	j, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
+	require.NoError(t, err)
+	require.NoError(t, j.CommitProgress(csvFiles[:1], true, true))
+	require.NoError(t, j.CommitCTIndex(100000))
+	require.NoError(t, j.Close())
+
+	// Reopening without changing the completed snapshot should carry all derived
+	// metadata into the new active job.
+	reopened, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
+	require.NoError(t, err)
+	job := latestJob(t, reopened)
+	require.Equal(t, completedIntervals(Interval{Start: 0, End: 99999}), job.CompletedIndices)
+	require.True(t, job.Coalesced)
+	require.True(t, job.UpdatedSMT)
+	require.Equal(t, int64(100000), job.UpdatedCTIndex)
+
+	// Extending the completed snapshot invalidates coalescing and SMT state,
+	// while preserving the last CT-index update value until a new DB update
+	// runs.
+	require.NoError(t, reopened.CommitProgress(csvFiles[1:2], false, false))
+
+	job = latestJob(t, reopened)
+	require.Equal(
+		t,
+		completedIntervals(
+			Interval{Start: 0, End: 199999},
+		),
+		job.CompletedIndices,
+	)
+	require.False(t, job.Coalesced)
+	require.False(t, job.UpdatedSMT)
+	require.Equal(t, int64(100000), job.UpdatedCTIndex)
 }
 
 // TestAddCompletedFilesIntervalScenarios verifies that completed files are

--- a/cmd/ingest/journal/journal_test.go
+++ b/cmd/ingest/journal/journal_test.go
@@ -68,7 +68,7 @@ func TestNewJournal(t *testing.T) {
 	require.NotEmpty(t, latestJob(t, j).EndTime)
 	require.False(t, latestJob(t, j).Coalesced)
 	require.False(t, latestJob(t, j).UpdatedSMT)
-	require.Equal(t, int64(-1), latestJob(t, j).RecordedCTLogSize)
+	require.Equal(t, int64(0), latestJob(t, j).RecordedCTLogSize)
 	requireJSONDoesNotContainFiles(t, journalFile)
 
 	j, err = NewJournal(journalFile, testJobConfig(t, false), "")

--- a/cmd/ingest/journal/journal_test.go
+++ b/cmd/ingest/journal/journal_test.go
@@ -68,7 +68,7 @@ func TestNewJournal(t *testing.T) {
 	require.NotEmpty(t, latestJob(t, j).EndTime)
 	require.False(t, latestJob(t, j).Coalesced)
 	require.False(t, latestJob(t, j).UpdatedSMT)
-	require.Equal(t, int64(-1), latestJob(t, j).UpdatedCTIndex)
+	require.Equal(t, int64(-1), latestJob(t, j).RecordedCTLogSize)
 	requireJSONDoesNotContainFiles(t, journalFile)
 
 	j, err = NewJournal(journalFile, testJobConfig(t, false), "")
@@ -152,7 +152,7 @@ func TestCommitProgressPhaseFlags(t *testing.T) {
 
 // TestJournalCarriesForwardState verifies that reopening the journal preserves
 // the previous snapshot metadata when the completed indices are unchanged, and
-// that extending the snapshot preserves the last CT-index update while
+// that extending the snapshot preserves the last recorded CT log size while
 // invalidating coalesce and SMT state until those phases run again.
 func TestJournalCarriesForwardState(t *testing.T) {
 	journalFile := filepath.Join(t.TempDir(), "journal.json")
@@ -162,7 +162,7 @@ func TestJournalCarriesForwardState(t *testing.T) {
 	j, err := NewJournal(journalFile, testJobConfig(t, false), csvPath)
 	require.NoError(t, err)
 	require.NoError(t, j.CommitProgress(csvFiles[:1], true, true))
-	require.NoError(t, j.CommitCTIndex(100000))
+	require.NoError(t, j.CommitCTLogSize(100000))
 	require.NoError(t, j.Close())
 
 	// Reopening without changing the completed snapshot should carry all derived
@@ -173,10 +173,10 @@ func TestJournalCarriesForwardState(t *testing.T) {
 	require.Equal(t, completedIntervals(Interval{Start: 0, End: 99999}), job.CompletedIndices)
 	require.True(t, job.Coalesced)
 	require.True(t, job.UpdatedSMT)
-	require.Equal(t, int64(100000), job.UpdatedCTIndex)
+	require.Equal(t, int64(100000), job.RecordedCTLogSize)
 
 	// Extending the completed snapshot invalidates coalescing and SMT state,
-	// while preserving the last CT-index update value until a new DB update
+	// while preserving the last recorded CT log size until a new DB update
 	// runs.
 	require.NoError(t, reopened.CommitProgress(csvFiles[1:2], false, false))
 
@@ -190,7 +190,7 @@ func TestJournalCarriesForwardState(t *testing.T) {
 	)
 	require.False(t, job.Coalesced)
 	require.False(t, job.UpdatedSMT)
-	require.Equal(t, int64(100000), job.UpdatedCTIndex)
+	require.Equal(t, int64(100000), job.RecordedCTLogSize)
 }
 
 // TestAddCompletedFilesIntervalScenarios verifies that completed files are

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -202,6 +202,9 @@ func mainFunction() error {
 			}
 			return cleanupDirty(ctx, conn)
 		},
+		UpdateCTIndex: func(ctx context.Context, ctLogURL string, size int64) error {
+			return conn.UpdateLastCTlogServerState(ctx, ctLogURL, size, nil)
+		},
 	})
 	if interrupted.Load() && errors.Is(err, context.Canceled) {
 		return fmt.Errorf("ingest interrupted")

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -202,7 +202,7 @@ func mainFunction() error {
 			}
 			return cleanupDirty(ctx, conn)
 		},
-		UpdateCTIndex: func(ctx context.Context, ctLogURL string, size int64) error {
+		RecordCTSize: func(ctx context.Context, ctLogURL string, size int64) error {
 			return conn.UpdateLastCTlogServerState(ctx, ctLogURL, size, nil)
 		},
 	})

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -203,7 +203,10 @@ func mainFunction() error {
 			return cleanupDirty(ctx, conn)
 		},
 		RecordCTSize: func(ctx context.Context, ctLogURL string, size int64) error {
-			return conn.UpdateLastCTlogServerState(ctx, ctLogURL, size, nil)
+			if err := conn.UpdateLastCTlogServerState(ctx, ctLogURL, size, nil); err != nil {
+				return fmt.Errorf("updating ctlog_server_last_status with url=%q size=%d: %w", ctLogURL, size, err)
+			}
+			return nil
 		},
 	})
 	if interrupted.Load() && errors.Is(err, context.Canceled) {

--- a/cmd/ingest/run.go
+++ b/cmd/ingest/run.go
@@ -108,7 +108,10 @@ func runIngest(ctx context.Context, cfg RunConfig, deps RunDependencies) error {
 		if err != nil {
 			return err
 		}
-		return deps.UpdateCTIndex(ctx, ctLogURL, size)
+		if err := deps.UpdateCTIndex(ctx, ctLogURL, size); err != nil {
+			return err
+		}
+		return j.CommitCTIndex(size)
 	}
 
 	if !jobCfg.IngestFiles {

--- a/cmd/ingest/run.go
+++ b/cmd/ingest/run.go
@@ -42,7 +42,7 @@ type RunDependencies struct {
 	RunBatch          func(*statistics.Stats, []string) error
 	Coalesce          func() error
 	UpdateSMT         func() error
-	UpdateCTIndex     func(context.Context, string, int64) error
+	RecordCTSize      func(context.Context, string, int64) error
 }
 
 func (cfg RunConfig) JobConfiguration() (journal.JobConfiguration, error) {
@@ -57,8 +57,8 @@ func (cfg RunConfig) validate() error {
 	if jobCfg.IngestFiles && cfg.Directory == "" {
 		return fmt.Errorf("ingest requires a directory")
 	}
-	if jobCfg.UpdateCTIndex && cfg.Directory == "" {
-		return fmt.Errorf("updatectindex requires a directory")
+	if jobCfg.RecordCTSize && cfg.Directory == "" {
+		return fmt.Errorf("recordctsize requires a directory")
 	}
 	return nil
 }
@@ -93,12 +93,12 @@ func runIngest(ctx context.Context, cfg RunConfig, deps RunDependencies) error {
 		updateSMT = func() error { return nil }
 	}
 
-	if jobCfg.UpdateCTIndex {
+	if jobCfg.RecordCTSize {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if deps.UpdateCTIndex == nil {
-			panic("missing CT index updater dependency")
+		if deps.RecordCTSize == nil {
+			panic("missing CT log size recorder dependency")
 		}
 		ctLogURL, err := deriveCTLogURLFromIngestDir(cfg.Directory)
 		if err != nil {
@@ -108,7 +108,7 @@ func runIngest(ctx context.Context, cfg RunConfig, deps RunDependencies) error {
 		if err != nil {
 			return err
 		}
-		if err := deps.UpdateCTIndex(ctx, ctLogURL, size); err != nil {
+		if err := deps.RecordCTSize(ctx, ctLogURL, size); err != nil {
 			return err
 		}
 		return j.CommitCTLogSize(size)

--- a/cmd/ingest/run.go
+++ b/cmd/ingest/run.go
@@ -114,6 +114,7 @@ func runIngest(ctx context.Context, cfg RunConfig, deps RunDependencies) error {
 		if err := j.CommitCTLogSize(size); err != nil {
 			return fmt.Errorf("recordctsize: persisting recorded CT log size %d to journal: %w", size, err)
 		}
+		fmt.Printf("recordctsize: recorded CT log size %d for URL %q\n", size, ctLogURL)
 		return nil
 	}
 

--- a/cmd/ingest/run.go
+++ b/cmd/ingest/run.go
@@ -102,16 +102,19 @@ func runIngest(ctx context.Context, cfg RunConfig, deps RunDependencies) error {
 		}
 		ctLogURL, err := deriveCTLogURLFromIngestDir(cfg.Directory)
 		if err != nil {
-			return err
+			return fmt.Errorf("recordctsize: deriving CT log URL from %q: %w", cfg.Directory, err)
 		}
 		size, err := completedCTLogSize(j, cfg.Directory)
 		if err != nil {
-			return err
+			return fmt.Errorf("recordctsize: computing CT log size from journal for %q: %w", cfg.Directory, err)
 		}
 		if err := deps.RecordCTSize(ctx, ctLogURL, size); err != nil {
-			return err
+			return fmt.Errorf("recordctsize: recording CT log size %d for URL %q: %w", size, ctLogURL, err)
 		}
-		return j.CommitCTLogSize(size)
+		if err := j.CommitCTLogSize(size); err != nil {
+			return fmt.Errorf("recordctsize: persisting recorded CT log size %d to journal: %w", size, err)
+		}
+		return nil
 	}
 
 	if !jobCfg.IngestFiles {

--- a/cmd/ingest/run.go
+++ b/cmd/ingest/run.go
@@ -111,7 +111,7 @@ func runIngest(ctx context.Context, cfg RunConfig, deps RunDependencies) error {
 		if err := deps.UpdateCTIndex(ctx, ctLogURL, size); err != nil {
 			return err
 		}
-		return j.CommitCTIndex(size)
+		return j.CommitCTLogSize(size)
 	}
 
 	if !jobCfg.IngestFiles {

--- a/cmd/ingest/run.go
+++ b/cmd/ingest/run.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -41,6 +42,7 @@ type RunDependencies struct {
 	RunBatch          func(*statistics.Stats, []string) error
 	Coalesce          func() error
 	UpdateSMT         func() error
+	UpdateCTIndex     func(context.Context, string, int64) error
 }
 
 func (cfg RunConfig) JobConfiguration() (journal.JobConfiguration, error) {
@@ -54,6 +56,9 @@ func (cfg RunConfig) validate() error {
 	}
 	if jobCfg.IngestFiles && cfg.Directory == "" {
 		return fmt.Errorf("ingest requires a directory")
+	}
+	if jobCfg.UpdateCTIndex && cfg.Directory == "" {
+		return fmt.Errorf("updatectindex requires a directory")
 	}
 	return nil
 }
@@ -86,6 +91,24 @@ func runIngest(ctx context.Context, cfg RunConfig, deps RunDependencies) error {
 	updateSMT := deps.UpdateSMT
 	if updateSMT == nil {
 		updateSMT = func() error { return nil }
+	}
+
+	if jobCfg.UpdateCTIndex {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if deps.UpdateCTIndex == nil {
+			panic("missing CT index updater dependency")
+		}
+		ctLogURL, err := deriveCTLogURLFromIngestDir(cfg.Directory)
+		if err != nil {
+			return err
+		}
+		size, err := completedCTLogSize(j, cfg.Directory)
+		if err != nil {
+			return err
+		}
+		return deps.UpdateCTIndex(ctx, ctLogURL, size)
 	}
 
 	if !jobCfg.IngestFiles {
@@ -239,4 +262,35 @@ func gcBeforeBatch(batchNum, batchCount int) error {
 	fmt.Printf("\nGC: freed %d MB\n", (memBefore.Alloc-memAfter.Alloc)/(1024*1024))
 	fmt.Printf("\nProcessing File Batch %d / %d\n", batchNum, batchCount)
 	return nil
+}
+
+func deriveCTLogURLFromIngestDir(ingestDir string) (string, error) {
+	if ingestDir == "" {
+		return "", fmt.Errorf("cannot derive CT log URL without ingest directory")
+	}
+	candidate := strings.ReplaceAll(filepath.Base(filepath.Clean(ingestDir)), "_", "/")
+	parsed, err := url.Parse(candidate)
+	if err != nil {
+		return "", fmt.Errorf("invalid derived CT log URL %q: %w", candidate, err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("invalid derived CT log URL %q", candidate)
+	}
+	return parsed.String(), nil
+}
+
+func completedCTLogSize(j *journal.Journal, ingestDir string) (int64, error) {
+	if j == nil {
+		return 0, fmt.Errorf("cannot compute CT log size without journal")
+	}
+	if len(j.Jobs) == 0 {
+		return 0, fmt.Errorf("journal has no jobs")
+	}
+	ingestDirBase := filepath.Base(filepath.Clean(ingestDir))
+	intervals := j.Jobs[len(j.Jobs)-1].CompletedIndices[ingestDirBase]
+	if len(intervals) == 0 {
+		return 0, fmt.Errorf("no completed indices recorded for ingest directory %q", ingestDirBase)
+	}
+	// Set the size of the ingested set from this CT log server to be END+1 of the interval [0,END].
+	return int64(intervals[0].End) + 1, nil
 }

--- a/cmd/ingest/run_test.go
+++ b/cmd/ingest/run_test.go
@@ -10,11 +10,14 @@ import (
 
 	"github.com/netsec-ethz/fpki/cmd/ingest/journal"
 	"github.com/netsec-ethz/fpki/pkg/statistics"
+	"github.com/netsec-ethz/fpki/pkg/tests/testdb"
 	"github.com/stretchr/testify/require"
 )
 
 const ingestTestBase = "fpki-ingest-test"
 
+// TestRunIngestScenarios exercises the main ingest control-flow variants,
+// including resume behavior, batching, follow-up phases, and cancellation.
 func TestRunIngestScenarios(t *testing.T) {
 	runIngestCases := map[string]struct {
 		// fileBatch controls the configured ingest batch size for the scenario.
@@ -325,6 +328,152 @@ func TestRunIngestScenarios(t *testing.T) {
 	}
 }
 
+// TestCompletedCTLogSize verifies that updatectindex derives the next safe CT
+// index from the first canonical completed interval for the current ingest dir.
+func TestCompletedCTLogSize(t *testing.T) {
+	t.Run("uses_first_canonical_completed_interval_end_plus_one", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "https:__ct.googleapis.com_logs_eu1_xenon2026h1")
+		cfg := newTestRunConfig(dir, filepath.Join(t.TempDir(), "journal.json"), 0, "updatectindex")
+
+		j := loadJournalForTest(t, cfg)
+		latestJobForTest(t, j).CompletedIndices = journal.CompletedIndices{
+			filepath.Base(dir): {
+				{Start: 0, End: 9},
+				{Start: 20, End: 29},
+			},
+		}
+
+		size, err := completedCTLogSize(j, dir)
+		require.NoError(t, err)
+		require.Equal(t, int64(10), size)
+	})
+
+	t.Run("fails_when_current_ingest_dir_has_no_completed_intervals", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "https:__ct.googleapis.com_logs_eu1_xenon2026h1")
+		cfg := newTestRunConfig(dir, filepath.Join(t.TempDir(), "journal.json"), 0, "updatectindex")
+
+		j := loadJournalForTest(t, cfg)
+		latestJobForTest(t, j).CompletedIndices = journal.CompletedIndices{
+			"other-log": {
+				{Start: 0, End: 9},
+			},
+		}
+
+		_, err := completedCTLogSize(j, dir)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), filepath.Base(dir))
+	})
+}
+
+// TestDeriveCTLogURLFromIngestDir verifies that encoded ingest-directory
+// basenames are converted into canonical CT log URLs and that malformed inputs
+// are rejected.
+func TestDeriveCTLogURLFromIngestDir(t *testing.T) {
+	testCases := map[string]struct {
+		dir     string
+		wantURL string
+		wantErr bool
+	}{
+		"derives canonical url from encoded basename": {
+			dir:     filepath.Join(t.TempDir(), "https:__ct.googleapis.com_logs_eu1_xenon2026h1"),
+			wantURL: "https://ct.googleapis.com/logs/eu1/xenon2026h1",
+		},
+		"fails when derived value is not a valid url": {
+			dir:     filepath.Join(t.TempDir(), "not-a-url"),
+			wantErr: true,
+		},
+		"fails when ingest directory is empty": {
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := deriveCTLogURLFromIngestDir(tc.dir)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantURL, got)
+		})
+	}
+}
+
+// TestRunIngestUpdateCTIndexUpdatesDB checks that the updatectindex strategy
+// creates and later advances the persisted CT log progress row in MySQL.
+func TestRunIngestUpdateCTIndexUpdatesDB(t *testing.T) {
+	// Prepare an isolated test DB and a cancellable context for the strategy run.
+	config, removeF := testdb.ConfigureTestDB(t)
+	defer removeF()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conn := testdb.Connect(t, config)
+	defer conn.Close()
+
+	dirBase := "https:__ct.googleapis.com_logs_eu1_xenon2026h1"
+	dir := filepath.Join(t.TempDir(), dirBase)
+	cfg := newTestRunConfig(dir, filepath.Join(t.TempDir(), "journal.json"), 0, "updatectindex")
+
+	// Seed the journal with one completed interval so updatectindex has progress
+	// to translate into a persisted CT log size.
+	jobCfg, err := cfg.JobConfiguration()
+	require.NoError(t, err)
+	j, err := journal.NewJournal(cfg.JournalFile, jobCfg, cfg.Directory)
+	require.NoError(t, err)
+	latestJobForTest(t, j).CompletedIndices = journal.CompletedIndices{
+		dirBase: {
+			{Start: 0, End: 9},
+		},
+	}
+	require.NoError(t, j.Close())
+
+	deps := RunDependencies{
+		NewJournal: func(cfg RunConfig, jobCfg journal.JobConfiguration) (*journal.Journal, error) {
+			return journal.NewJournal(cfg.JournalFile, jobCfg, cfg.Directory)
+		},
+		UpdateCTIndex: func(ctx context.Context, ctLogURL string, size int64) error {
+			return conn.UpdateLastCTlogServerState(ctx, ctLogURL, size, nil)
+		},
+	}
+
+	// First run should create the DB row from the initial completed interval.
+	err = runIngest(ctx, cfg, deps)
+	require.NoError(t, err)
+
+	wantURL, err := deriveCTLogURLFromIngestDir(dir)
+	require.NoError(t, err)
+	gotSize, gotSTH, err := conn.LastCTlogServerState(ctx, wantURL)
+	require.NoError(t, err)
+	require.Equal(t, int64(10), gotSize)
+	require.Nil(t, gotSTH)
+
+	// Extend the completed coverage and rerun so the same DB row is advanced.
+	reopened, err := journal.NewJournal(cfg.JournalFile, jobCfg, cfg.Directory)
+	require.NoError(t, err)
+	latestJobForTest(t, reopened).CompletedIndices = journal.CompletedIndices{
+		dirBase: {
+			{Start: 0, End: 19},
+		},
+	}
+	require.NoError(t, reopened.Close())
+
+	err = runIngest(ctx, cfg, deps)
+	require.NoError(t, err)
+
+	gotSize, gotSTH, err = conn.LastCTlogServerState(ctx, wantURL)
+	require.NoError(t, err)
+	require.Equal(t, int64(20), gotSize)
+	require.Nil(t, gotSTH)
+}
+
+// makeIngestTestFiles creates a minimal bundled ingest tree with three
+// sequential gzip files and returns the ingest root plus file paths in order.
 func makeIngestTestFiles(t *testing.T) (string, []string) {
 	t.Helper()
 
@@ -344,6 +493,8 @@ func makeIngestTestFiles(t *testing.T) (string, []string) {
 	return root, files
 }
 
+// newTestRunConfig builds a compact RunConfig for unit tests, overriding only
+// the fields that matter to the scenario under test.
 func newTestRunConfig(dir string, journalFile string, fileBatch int, strategy string) RunConfig {
 	return RunConfig{
 		Directory:    dir,
@@ -356,6 +507,8 @@ func newTestRunConfig(dir string, journalFile string, fileBatch int, strategy st
 	}
 }
 
+// newTestDeps returns a dependency set that records batch execution order and
+// follow-up phase counts, with optional forced failure on a chosen batch.
 func newTestDeps(
 	t *testing.T,
 	runOrder *[][]string,
@@ -390,10 +543,13 @@ func newTestDeps(
 	}
 }
 
+// assertErr is a sentinel error used to force controlled batch failures.
 type assertErr struct{}
 
 func (assertErr) Error() string { return "forced batch failure" }
 
+// loadJournalForTest reopens the journal using the config's current strategy so
+// tests can inspect the persisted completed-index snapshot.
 func loadJournalForTest(t *testing.T, cfg RunConfig) *journal.Journal {
 	t.Helper()
 	jobCfg, err := cfg.JobConfiguration()
@@ -403,20 +559,26 @@ func loadJournalForTest(t *testing.T, cfg RunConfig) *journal.Journal {
 	return j
 }
 
+// completedIngestTestIntervals builds the expected completed-index map for the
+// synthetic ingest root created by makeIngestTestFiles.
 func completedIngestTestIntervals(intervals ...journal.Interval) journal.CompletedIndices {
 	return journal.CompletedIndices{
 		ingestTestBase: intervals,
 	}
 }
 
-func latestJobForTest(t *testing.T, j *journal.Journal) journal.Job {
+// latestJobForTest returns the most recent journal job entry for in-place
+// inspection or mutation within a test.
+func latestJobForTest(t *testing.T, j *journal.Journal) *journal.Job {
 	t.Helper()
 	require.NotEmpty(t, j.Jobs)
-	return j.Jobs[len(j.Jobs)-1]
+	return &j.Jobs[len(j.Jobs)-1]
 }
 
-func previousJobForTest(t *testing.T, j *journal.Journal) journal.Job {
+// previousJobForTest returns the journal entry immediately before the latest
+// one, which is useful when assertions need the carried-forward prior snapshot.
+func previousJobForTest(t *testing.T, j *journal.Journal) *journal.Job {
 	t.Helper()
 	require.GreaterOrEqual(t, len(j.Jobs), 2)
-	return j.Jobs[len(j.Jobs)-2]
+	return &j.Jobs[len(j.Jobs)-2]
 }

--- a/cmd/ingest/run_test.go
+++ b/cmd/ingest/run_test.go
@@ -328,12 +328,12 @@ func TestRunIngestScenarios(t *testing.T) {
 	}
 }
 
-// TestCompletedCTLogSize verifies that updatectindex derives the next safe CT
+// TestCompletedCTLogSize verifies that recordctsize derives the next safe CT
 // index from the first canonical completed interval for the current ingest dir.
 func TestCompletedCTLogSize(t *testing.T) {
 	t.Run("uses_first_canonical_completed_interval_end_plus_one", func(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "https:__ct.googleapis.com_logs_eu1_xenon2026h1")
-		cfg := newTestRunConfig(dir, filepath.Join(t.TempDir(), "journal.json"), 0, "updatectindex")
+		cfg := newTestRunConfig(dir, filepath.Join(t.TempDir(), "journal.json"), 0, "recordctsize")
 
 		j := loadJournalForTest(t, cfg)
 		latestJobForTest(t, j).CompletedIndices = journal.CompletedIndices{
@@ -350,7 +350,7 @@ func TestCompletedCTLogSize(t *testing.T) {
 
 	t.Run("fails_when_current_ingest_dir_has_no_completed_intervals", func(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "https:__ct.googleapis.com_logs_eu1_xenon2026h1")
-		cfg := newTestRunConfig(dir, filepath.Join(t.TempDir(), "journal.json"), 0, "updatectindex")
+		cfg := newTestRunConfig(dir, filepath.Join(t.TempDir(), "journal.json"), 0, "recordctsize")
 
 		j := loadJournalForTest(t, cfg)
 		latestJobForTest(t, j).CompletedIndices = journal.CompletedIndices{
@@ -403,9 +403,9 @@ func TestDeriveCTLogURLFromIngestDir(t *testing.T) {
 	}
 }
 
-// TestRunIngestUpdateCTIndexUpdatesDB checks that the updatectindex strategy
+// TestRunIngestRecordCTSizeUpdatesDB checks that the recordctsize strategy
 // creates and later advances the persisted CT log progress row in MySQL.
-func TestRunIngestUpdateCTIndexUpdatesDB(t *testing.T) {
+func TestRunIngestRecordCTSizeUpdatesDB(t *testing.T) {
 	// Prepare an isolated test DB and a cancellable context for the strategy run.
 	config, removeF := testdb.ConfigureTestDB(t)
 	defer removeF()
@@ -418,9 +418,9 @@ func TestRunIngestUpdateCTIndexUpdatesDB(t *testing.T) {
 
 	dirBase := "https:__ct.googleapis.com_logs_eu1_xenon2026h1"
 	dir := filepath.Join(t.TempDir(), dirBase)
-	cfg := newTestRunConfig(dir, filepath.Join(t.TempDir(), "journal.json"), 0, "updatectindex")
+	cfg := newTestRunConfig(dir, filepath.Join(t.TempDir(), "journal.json"), 0, "recordctsize")
 
-	// Seed the journal with one completed interval so updatectindex has progress
+	// Seed the journal with one completed interval so recordctsize has progress
 	// to translate into a persisted CT log size.
 	jobCfg, err := cfg.JobConfiguration()
 	require.NoError(t, err)
@@ -437,7 +437,7 @@ func TestRunIngestUpdateCTIndexUpdatesDB(t *testing.T) {
 		NewJournal: func(cfg RunConfig, jobCfg journal.JobConfiguration) (*journal.Journal, error) {
 			return journal.NewJournal(cfg.JournalFile, jobCfg, cfg.Directory)
 		},
-		UpdateCTIndex: func(ctx context.Context, ctLogURL string, size int64) error {
+		RecordCTSize: func(ctx context.Context, ctLogURL string, size int64) error {
 			return conn.UpdateLastCTlogServerState(ctx, ctLogURL, size, nil)
 		},
 	}

--- a/cmd/ingest/run_test.go
+++ b/cmd/ingest/run_test.go
@@ -454,7 +454,7 @@ func TestRunIngestUpdateCTIndexUpdatesDB(t *testing.T) {
 	require.Nil(t, gotSTH)
 	reopenedJournal, err := journal.NewJournal(cfg.JournalFile, jobCfg, cfg.Directory)
 	require.NoError(t, err)
-	require.Equal(t, int64(10), latestJobForTest(t, reopenedJournal).UpdatedCTIndex)
+	require.Equal(t, int64(10), latestJobForTest(t, reopenedJournal).RecordedCTLogSize)
 	require.NoError(t, reopenedJournal.Close())
 
 	// Extend the completed coverage and rerun so the same DB row is advanced.
@@ -476,7 +476,7 @@ func TestRunIngestUpdateCTIndexUpdatesDB(t *testing.T) {
 	require.Nil(t, gotSTH)
 	finalJournal, err := journal.NewJournal(cfg.JournalFile, jobCfg, cfg.Directory)
 	require.NoError(t, err)
-	require.Equal(t, int64(20), latestJobForTest(t, finalJournal).UpdatedCTIndex)
+	require.Equal(t, int64(20), latestJobForTest(t, finalJournal).RecordedCTLogSize)
 	require.NoError(t, finalJournal.Close())
 }
 

--- a/cmd/ingest/run_test.go
+++ b/cmd/ingest/run_test.go
@@ -452,6 +452,10 @@ func TestRunIngestUpdateCTIndexUpdatesDB(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(10), gotSize)
 	require.Nil(t, gotSTH)
+	reopenedJournal, err := journal.NewJournal(cfg.JournalFile, jobCfg, cfg.Directory)
+	require.NoError(t, err)
+	require.Equal(t, int64(10), latestJobForTest(t, reopenedJournal).UpdatedCTIndex)
+	require.NoError(t, reopenedJournal.Close())
 
 	// Extend the completed coverage and rerun so the same DB row is advanced.
 	reopened, err := journal.NewJournal(cfg.JournalFile, jobCfg, cfg.Directory)
@@ -470,6 +474,10 @@ func TestRunIngestUpdateCTIndexUpdatesDB(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(20), gotSize)
 	require.Nil(t, gotSTH)
+	finalJournal, err := journal.NewJournal(cfg.JournalFile, jobCfg, cfg.Directory)
+	require.NoError(t, err)
+	require.Equal(t, int64(20), latestJobForTest(t, finalJournal).UpdatedCTIndex)
+	require.NoError(t, finalJournal.Close())
 }
 
 // makeIngestTestFiles creates a minimal bundled ingest tree with three

--- a/pkg/db/mysql/certs.go
+++ b/pkg/db/mysql/certs.go
@@ -304,7 +304,10 @@ func (c *mysqlDB) UpdateLastCTlogServerState(ctx context.Context, url string,
 
 	str := "REPLACE INTO ctlog_server_last_status (url_hash, size, sth) VALUES (?,?,?)"
 	_, err := c.db.ExecContext(ctx, str, common.SHA256Hash([]byte(url)), size, sth)
-	return err
+	if err != nil {
+		return fmt.Errorf("updating ctlog_server_last_status for url=%q size=%d: %w", url, size, err)
+	}
+	return nil
 }
 
 // PruneCerts removes all certificates that are no longer valid according to the paramter.

--- a/pkg/db/mysql/mysql_test.go
+++ b/pkg/db/mysql/mysql_test.go
@@ -604,6 +604,15 @@ func TestLastCTlogServerState(t *testing.T) {
 	require.Equal(t, int64(222), n)
 	require.Equal(t, sth, []byte{2, 2, 2})
 
+	// Large CT log sizes should also round-trip without overflowing the schema.
+	const largeCTLogSize = int64(1 << 60)
+	err = conn.UpdateLastCTlogServerState(ctx, url2, largeCTLogSize, []byte{6, 0})
+	require.NoError(t, err)
+	n, sth, err = conn.LastCTlogServerState(ctx, url2)
+	require.NoError(t, err)
+	require.Equal(t, largeCTLogSize, n)
+	require.Equal(t, sth, []byte{6, 0})
+
 	// Unknown urls still give out -1:
 	n, sth, err = conn.LastCTlogServerState(ctx, "doesnt exist")
 	require.NoError(t, err)

--- a/tools/create_schema.sh
+++ b/tools/create_schema.sh
@@ -169,7 +169,7 @@ USE $DBNAME;
 -- Stores the last valid status that was ingested, per CT log server URL
 CREATE TABLE ctlog_server_last_status (
   url_hash VARBINARY(32) NOT NULL,
-  size INTEGER,
+  size BIGINT,
   sth BLOB,
 
   PRIMARY KEY (url_hash)


### PR DESCRIPTION
The ingest CLI should record the "size" (last index + 1) of the CT log server it ingested.
To do so, add a new type of strategy `updatectindex`, that writes it to the DB.

Record it also in the journal file.
When ingesting more certificate files, keep the previous size in the DB.

Closes #101 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/fpki/112)
<!-- Reviewable:end -->
